### PR TITLE
Added --host and --port to 1090 app.

### DIFF
--- a/apps/src/1090.rs
+++ b/apps/src/1090.rs
@@ -11,19 +11,15 @@ use apps::Airplanes;
 #[clap(version = "1.0", author = "wcampbell <wcampbell1995@gmail.com>")]
 #[clap(setting = AppSettings::ColoredHelp)]
 struct Options {
-    #[clap(long)]
-    host: Option<String>,
-    #[clap(long)]
-    port: Option<u16>,
+    #[clap(long, default_value = "localhost")]
+    host: String,
+    #[clap(long, default_value = "30002")]
+    port: u16,
 }
 
 fn main() {
     let options = Options::parse();
-    let stream = TcpStream::connect((
-        options.host.unwrap_or_else(|| "localhost".to_string()),
-        options.port.unwrap_or(30002),
-    ))
-    .unwrap();
+    let stream = TcpStream::connect((options.host, options.port)).unwrap();
     let mut reader = BufReader::new(stream);
     let mut input = String::new();
     let mut airplains = Airplanes::new();

--- a/apps/src/radar.rs
+++ b/apps/src/radar.rs
@@ -79,6 +79,10 @@ impl FromStr for City {
 #[clap(version = "1.0", author = "wcampbell <wcampbell1995@gmail.com>")]
 #[clap(setting = AppSettings::ColoredHelp)]
 struct Opts {
+    #[clap(long, default_value = "localhost")]
+    host: String,
+    #[clap(long, default_value = "30002")]
+    port: u16,
     /// Antenna location latitude
     #[clap(long)]
     lat: f64,
@@ -107,7 +111,7 @@ fn main() {
     let disable_lat_long = opts.disable_lat_long;
 
     // Setup non-blocking TcpStream
-    let stream = TcpStream::connect(("127.0.0.1", 30002)).unwrap();
+    let stream = TcpStream::connect((opts.host, opts.port)).unwrap();
     stream
         .set_read_timeout(Some(std::time::Duration::from_millis(100)))
         .unwrap();


### PR DESCRIPTION
Added `--host` and `--port` to the 1090 and radar apps.

(Thanks for doing this!  I'm very excited by a Rust ADS-B decoder.)