### PR TITLE
Add ARM ci/release binaries

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -1,0 +1,45 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  release:
+    types:
+      - created
+
+name: binaries
+
+jobs:
+  # release binaries
+  release-bins:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        targets:
+          - x86_64-unknown-linux-gnu
+          - armv7-unknown-linux-gnueabihf
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --release --workspace --target ${{ matrix.targets }}
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: radar-${{ matrix.targets }}
+          path: target/${{ matrix.targets }}/release/radar
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: 1090-${{ matrix.targets }}
+          path: target/${{ matrix.targets }}/release/1090

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,17 @@
 on: [push, pull_request]
 
-name: CI
+name: ci
 
 jobs:
-  check:
-    name: Build
+  # build, test all supported targets
+  build-test-stable:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        targets:
+          - x86_64-unknown-linux-gnu
+          - armv7-unknown-linux-gnueabihf
+
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -15,51 +21,35 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
+          use-cross: true
           command: build
-          args: --workspace
+          args: --workspace --target ${{ matrix.targets }}
 
-  test:
-    name: Test Suite
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
       - uses: actions-rs/cargo@v1
         with:
+          use-cross: true
           command: test
-          args: --workspace
+          args: --workspace --target ${{ matrix.targets }}
 
-  fmt:
-    name: Rustfmt
+  # fmt and clippy on nightly builds
+  fmt-clippy-nightly:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: nightly
           override: true
+          components: rustfmt, clippy
       - run: rustup component add rustfmt
+
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
 
-  clippy:
-    name: Clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add clippy
       - uses: actions-rs/cargo@v1
         with:
           command: clippy


### PR DESCRIPTION
Add release binaries for arm and linux targets on master branch pushes
or releases

Use nightly for clippy

Closes #35 