### PR TITLE
feat: rename radar `--cities` as `--locations`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Client applications use this library to display the data accumulated from an ADS
 An ADS-B client for the terminal written in Rust. Radar connects to an ADS-B demodulation server
 and stores this info, allowing an operator to control the display of the data.
 
-- **Map Tab** - Plot currently detected aircraft on lat/long grid. Add known locations with `--cities` option.
+- **Map Tab** - Plot currently detected aircraft on lat/long grid. Add known locations with `--locations` option.
 - **Coverage Tab** - Plot all detected aircraft lat/long positions since starting radar. Features grayscale heatmap.
 - **Aircraft Tab** - Show detailed table of information about currently detected aircraft. Set aircraft position as center lat/long.
 - **gpsd** - Derive lat/long from a gpsd instance using `--gpsd` flag.
@@ -34,7 +34,7 @@ This application uses [tui-rs](https://github.com/fdehau/tui-rs) for generating 
 ```text
 # Startup "radar" display in tui relative to your antenna position
 > cd apps
-> cargo r --bin radar --release -- --lat="50.0" --long="50.0" --cities "(name,lat,long)" "(name,lat,long)"
+> cargo r --bin radar --release -- --lat="50.0" --long="50.0" --locations "(name,lat,long)" "(name,lat,long)"
 ```
 
 #### 1090

--- a/apps/README.md
+++ b/apps/README.md
@@ -5,38 +5,32 @@ See main README.md for app sample images.
 ## 1090
 ```
 1090 0.4.0
-
 wcampbell0x2a
-
 Dump ADS-B protocol info from demodulator
 
 USAGE:
     1090 [OPTIONS]
 
 OPTIONS:
-        --debug                Display debug of adsb::Frame
-        --disable-airplanes    Disable display of currently tracked airplanes lat/long/altitude
-    -h, --help                 Print help information
-        --host <HOST>          ip address of ADS-B demodulated bytes server [default: localhost]
-        --panic-decode         Panic on adsb_deku::Frame::from_bytes() error
-        --panic-display        Panic on adsb_deku::Frame::fmt::Display not implemented
-        --port <PORT>          port of ADS-B demodulated bytes server [default: 30002]
-    -V, --version              Print version information
+        --debug            Display debug of adsb::Frame
+    -h, --help             Print help information
+        --host <HOST>      ip address of ADS-B demodulated bytes server [default: localhost]
+        --panic-decode     Panic on adsb_deku::Frame::from_bytes() error
+        --panic-display    Panic on adsb_deku::Frame::fmt::Display not implemented
+        --port <PORT>      port of ADS-B demodulated bytes server [default: 30002]
+    -V, --version          Print version information
 ```
 
 ## radar
 ```
 radar 0.4.0
-
 wcampbell0x2a
-
 TUI Display of ADS-B protocol info from demodulator
 
 USAGE:
     radar [OPTIONS] --lat <LAT> --long <LONG>
 
 OPTIONS:
-        --cities <CITIES>...           Vector of cities [(name, lat, long),..]
         --disable-lat-long             Disable output of latitude and longitude on display
         --filter-time <FILTER_TIME>    Seconds since last message from airplane, triggers removal of
                                        airplane after time is up [default: 10]
@@ -45,6 +39,7 @@ OPTIONS:
     -h, --help                         Print help information
         --host <HOST>                  [default: localhost]
         --lat <LAT>                    Antenna location latitude
+        --locations <LOCATIONS>...     Vector of location [(name, lat, long),..]
         --log-folder <LOG_FOLDER>      [default: logs]
         --long <LONG>                  Antenna location longitude
         --port <PORT>                  [default: 30002]

--- a/apps/src/radar.rs
+++ b/apps/src/radar.rs
@@ -77,15 +77,15 @@ const TUI_START_MARGIN: u16 = 1;
 /// width of tui top bar
 const TUI_BAR_WIDTH: u16 = 3;
 
-/// Parsing struct for the --cities clap parameter
+/// Parsing struct for the --locations clap parameter
 #[derive(Debug, Clone)]
-pub struct City {
+pub struct Location {
     name: String,
     lat: f64,
     long: f64,
 }
 
-impl FromStr for City {
+impl FromStr for Location {
     type Err = ParseFloatError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -128,9 +128,9 @@ struct Opts {
     #[clap(long)]
     long: f64,
 
-    /// Vector of cities [(name, lat, long),..]
+    /// Vector of location [(name, lat, long),..]
     #[clap(long, multiple_values(true))]
-    cities: Vec<City>,
+    locations: Vec<Location>,
 
     /// Disable output of latitude and longitude on display
     #[clap(long)]
@@ -780,8 +780,8 @@ fn build_tab_map<A: tui::backend::Backend>(
 
             let (lat_diff, long_diff) = scale_lat_long(settings.scale);
 
-            // draw cities
-            draw_cities(ctx, settings, lat_diff, long_diff);
+            // draw locations
+            draw_locations(ctx, settings, lat_diff, long_diff);
 
             // draw ADSB tab airplanes
             for key in adsb_airplanes.0.keys() {
@@ -833,8 +833,8 @@ fn build_tab_coverage<A: tui::backend::Backend>(
 
             let (lat_diff, long_diff) = scale_lat_long(settings.scale);
 
-            // draw cities
-            draw_cities(ctx, settings, lat_diff, long_diff);
+            // draw locations
+            draw_locations(ctx, settings, lat_diff, long_diff);
 
             // draw ADSB tab airplanes
             for (lat, long, seen_number, _) in coverage_airplanes.iter() {
@@ -962,14 +962,14 @@ fn draw_lines(ctx: &mut tui::widgets::canvas::Context<'_>) {
     });
 }
 
-/// Draw cities on the map
-fn draw_cities(
+/// Draw locations on the map
+fn draw_locations(
     ctx: &mut tui::widgets::canvas::Context<'_>,
     settings: &Settings,
     lat_diff: f64,
     long_diff: f64,
 ) {
-    for city in &settings.opts.cities {
+    for city in &settings.opts.locations {
         let lat = ((city.lat - settings.lat) / lat_diff) * MAX_PLOT_HIGH;
         let long = ((city.long - settings.long) / long_diff) * MAX_PLOT_HIGH;
 


### PR DESCRIPTION
As discussed in #62, rename `cities` as `locations` in the radar application. I myself use this to show airports, so this is way more accurate even in my own use case.