### PR TITLE
feat: use clap wrap_help

### DIFF
--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/1090.rs"
 adsb_deku = { path = "../", version = "0.5" }
 hex = "0.4"
 crossterm = "0.22"
-clap = {version = "3.0.0-rc.9", features = ["color", "derive"]}
+clap = {version = "3.0.0-rc.9", features = ["color", "derive", "wrap_help"]}
 # CHANGE WHEN https://github.com/fdehau/tui-rs/issues/529 is released
 #tui = {version = "0.16", default-features = false, features = ["crossterm"]}
 tui = { git = "https://github.com/fdehau/tui-rs.git", branch = "master", features = ["crossterm"] }

--- a/apps/README.md
+++ b/apps/README.md
@@ -32,9 +32,8 @@ USAGE:
 
 OPTIONS:
         --disable-lat-long             Disable output of latitude and longitude on display
-        --filter-time <FILTER_TIME>    Seconds since last message from airplane, triggers removal of
-                                       airplane after time is up [default: 10]
-        --gpsd                         Enable automatic updating of lat/lon from gpsd
+        --filter-time <FILTER_TIME>    Seconds since last message from airplane, triggers removal of airplane after time is up [default: 10]
+        --gpsd                         Enable automatic updating of lat/lon from gpsd(https://gpsd.io/) server
         --gpsd-ip <GPSD_IP>            Ip address of gpsd [default: localhost]
     -h, --help                         Print help information
         --host <HOST>                  [default: localhost]
@@ -43,10 +42,8 @@ OPTIONS:
         --log-folder <LOG_FOLDER>      [default: logs]
         --long <LONG>                  Antenna location longitude
         --port <PORT>                  [default: 30002]
-        --scale <SCALE>                Zoom level of Radar and Coverage (+=zoom out/-=zoom in)
-                                       [default: 1.4]
-        --touchscreen                  Enable three tabs on left side of screen for zoom out/zoom
-                                       in/and reset
+        --scale <SCALE>                Zoom level of Radar and Coverage (+=zoom out/-=zoom in) [default: 1.4]
+        --touchscreen                  Enable three tabs on left side of screen for zoom out/zoom in/and reset
     -V, --version                      Print version information
 ```
 

--- a/apps/src/radar.rs
+++ b/apps/src/radar.rs
@@ -140,7 +140,7 @@ struct Opts {
     #[clap(long, default_value = "1.4")]
     scale: f64,
 
-    /// Enable automatic updating of lat/lon from gpsd
+    /// Enable automatic updating of lat/lon from gpsd(https://gpsd.io/) server
     #[clap(long)]
     gpsd: bool,
 


### PR DESCRIPTION
Respect terminal width when outputting the `--help` usage.

Add context to what gpsd means