### PR TITLE
feat: use fmt::Display for logging

### DIFF
--- a/apps/src/radar.rs
+++ b/apps/src/radar.rs
@@ -457,7 +457,7 @@ see https://github.com/rsadsb/adsb_deku#serverdemodulationexternal-applications 
             if df_adsb {
                 // parse the entire DF frame
                 if let Ok((_, frame)) = Frame::from_bytes((&bytes, 0)) {
-                    debug!("message: {:#?}", frame);
+                    debug!("message: {}", frame);
                     adsb_airplanes.action(frame);
                 }
             }


### PR DESCRIPTION
Log ADSB data just as dump1090 does, in our log file instead of using
derieved Debug fmt