### PR TITLE
fix: fix moving lat/lon while in gpsd mode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ matrix.toolchain }}
           target: ${{ matrix.targets }}
           override: true
       - uses: actions-rs/cargo@v1


### PR DESCRIPTION
Remove checking the lat_long_mutated inside the gpsd reading thread.
This doens't need to be read there, and should be read from just when
checking the new value from that thread. This was also renamed to
cstom_lat_long and switched to just a bool