### PR TITLE
Add range and distance check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### adsb_deku
 - refactor: improve `fmt::Display` of `ControlField`
 - fix(breaking): change `OperationalCodeSurface.reserved` from `u16` to `u8`
+- fix: Handle negative m value. Thanks ([@amacd31](https://github.com/amacd31)) ([!78](https://github.com/rsadsb/adsb_deku/pull/78))
 
 ### apps/radar
 - fix: breaking clap change, same syntax as before for `--cities`
@@ -28,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat(breaking): use mercator projection for map/coverage tabs, change `--scale` usage
 - feat: Update to clap v3.0.0
 - feat(breaking): change `--scale` to use * and /
+- feat: Add ctrl+c as quit option
 
 ### apps/1090
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,22 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-`adsb_deku` follows semvar when versioning, but apps are not required to follow the semvar convention.
+`adsb_deku` follows semvar when versioning, but `apps` are not required to follow the semvar convention.
 
 ## [Unreleased]
 
 ### adsb_deku
 - refactor: improve `fmt::Display` of `ControlField`
 - fix(breaking): change `OperationalCodeSurface.reserved` from `u16` to `u8`
-- fix: Handle negative m value. Thanks ([@amacd31](https://github.com/amacd31)) ([!78](https://github.com/rsadsb/adsb_deku/pull/78))
+- fix: Handle negative cpr `m` value. Thanks ([@amacd31](https://github.com/amacd31)) ([!78](https://github.com/rsadsb/adsb_deku/pull/78))
+- bump msrv to `1.58.1`
 
 ### apps/radar
 - fix: breaking clap change, same syntax as before for `--cities`
 - fix: time related unwrap(). Thanks ([@Jachdich](https://github.com/Jachdich)) ([!57](https://github.com/rsadsb/adsb_deku/pull/57))
 - feat: change logs to rotate daily instead of hourly
-- feat: add debug tracing of bytes and `Frame`
+- feat: add debug and error tracing of bytes and `adsb_deku::Frame`
 - feat: improve performance of latitude/longitude calculation
-- fix: breaking clap change, same syntax as before for `--cities`
 - feat: add Mouse control for Map/Coverage lat/long position
 - feat: add Mouse control for tab selection
 - feat: add `--touchscreen`, three left-side buttons for zoom out, zoom in, reset screen actions
@@ -30,8 +30,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: Update to clap v3.0.0
 - feat(breaking): change `--scale` to use * and /
 - feat: Add ctrl+c as quit option
+- feat: fix position mis decoding with ([!101](https://github.com/rsadsb/adsb_deku/pull/101)), fixing: ([#21](https://github.com/rsadsb/adsb_deku/issues/21))
+- feat(breaking): `--cities` has been renamed to `--locations`
+- bump msrv to `1.58.1`
 
 ### apps/1090
+- bump msrv to `1.58.1`
 
 ### Other
 - feat: add test, check, and release binaries for x86_64-unknown-linux-gnu and armv7-unknown-linux-gnueabihf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ version = "0.5.0"
 dependencies = [
  "adsb_deku",
  "anyhow",
- "clap 3.0.10",
+ "clap 3.0.13",
  "crossterm",
  "gpsd_proto",
  "hex",
@@ -87,9 +87,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
+checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
 dependencies = [
  "addr2line",
  "cc",
@@ -176,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.10"
+version = "3.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a30c3bf9ff12dfe5dae53f0a96e0febcd18420d1c0e7fad77796d9d5c4b5375"
+checksum = "08799f92c961c7a1cf0cc398a9073da99e21ce388b46372c37f3191f2f3eed3e"
 dependencies = [
  "atty",
  "bitflags",
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.6"
+version = "3.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517358c28fcef6607bf6f76108e02afad7e82297d132a6b846dcc1fc3efcd153"
+checksum = "0fd2078197a22f338bd4fbf7d6387eb6f0d6a3c69e6cbc09f5c93e97321fd92a"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -528,15 +528,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.113"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
+checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]
@@ -636,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "num_threads"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a1eb3a36534514077c1e079ada2fb170ef30c47d203aa6916138cf882ecd52"
+checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
 dependencies = [
  "libc",
 ]
@@ -892,9 +892,9 @@ checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
-version = "1.0.134"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b3c34c1690edf8174f5b289a336ab03f568a4460d8c6df75f2f3a692b3bc6a"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 
 [[package]]
 name = "serde_cbor"
@@ -908,9 +908,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.134"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784ed1fbfa13fe191077537b0d70ec8ad1e903cfe04831da608aa36457cb653d"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -919,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edde269018d33d7146dd074e5f7da6fef9b0a957507454c867caa0852c560a9a"
+checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -1055,18 +1055,18 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d54b9298e05179c335de2b9645d061255bcd5155f843b3e328d2cfe0a5b413"
+checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
 dependencies = [
  "itoa 1.0.1",
  "libc",
@@ -1148,9 +1148,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77be66445c4eeebb934a7340f227bfe7b338173d3f8c00a60a5a58005c9faecf"
+checksum = "5312f325fe3588e277415f5a6cca1f4ccad0f248c4cd5a4bd33032d7286abc22"
 dependencies = [
  "ansi_term",
  "lazy_static",

--- a/apps/README.md
+++ b/apps/README.md
@@ -31,22 +31,68 @@ USAGE:
     radar [OPTIONS] --lat <LAT> --long <LONG>
 
 OPTIONS:
-        --disable-lat-long             Disable output of latitude and longitude on display
-        --filter-time <FILTER_TIME>    Seconds since last message from airplane, triggers removal of airplane after time is up [default:
-                                       10]
-        --gpsd                         Enable automatic updating of lat/lon from gpsd(https://gpsd.io/) server
-        --gpsd-ip <GPSD_IP>            Ip address of gpsd [default: localhost]
-    -h, --help                         Print help information
-        --host <HOST>                  ip address / hostname of ADS-B server / demodulator [default: 127.0.0.1]
-        --lat <LAT>                    Antenna location latitude
-        --limit-parsing                Limit parsing of ADS-B messages to `DF::ADSB(17)` messages
-        --locations <LOCATIONS>...     Vector of location [(name, lat, long),..]
-        --log-folder <LOG_FOLDER>      [default: logs]
-        --long <LONG>                  Antenna location longitude
-        --port <PORT>                  port of ADS-B server / demodulator [default: 30002]
-        --scale <SCALE>                Zoom level of Radar and Coverage (-=zoom out/+=zoom in) [default: .12]
-        --touchscreen                  Enable three tabs on left side of screen for zoom out/zoom in/and reset
-    -V, --version                      Print version information
+        --disable-lat-long
+            Disable output of latitude and longitude on display
+
+        --filter-time <FILTER_TIME>
+            Seconds since last message from airplane, triggers removal of airplane after time is up
+
+            [default: 10]
+
+        --gpsd
+            Enable automatic updating of lat/lon from gpsd(https://gpsd.io/) server.
+
+            This overwrites the `--lat` and `--long`
+
+        --gpsd-ip <GPSD_IP>
+            Ip address of gpsd
+
+            [default: localhost]
+
+    -h, --help
+            Print help information
+
+        --host <HOST>
+            ip address / hostname of ADS-B server / demodulator
+
+            [default: 127.0.0.1]
+
+        --lat <LAT>
+            Antenna location latitude, this use for aircraft position algorithms.
+
+            This is overwritten when using the `--gpsd` option.
+
+        --limit-parsing
+            Limit parsing of ADS-B messages to `DF::ADSB(17)` num_messages
+
+            This can improve performance of just needing to read radar related messages
+
+        --locations <LOCATIONS>...
+            Vector of location [(name, lat, long),..]
+
+        --log-folder <LOG_FOLDER>
+            [default: logs]
+
+        --long <LONG>
+            Antenna location longitude
+
+            This is overwritten when using the `--gpsd` option.
+
+        --port <PORT>
+            port of ADS-B server / demodulator
+
+            [default: 30002]
+
+        --scale <SCALE>
+            Zoom level of Radar and Coverage (-=zoom out/+=zoom in)
+
+            [default: .12]
+
+        --touchscreen
+            Enable three tabs on left side of screen for zoom out/zoom in/and reset
+
+    -V, --version
+            Print version information
 ```
 
 ### Logging

--- a/apps/src/lib.rs
+++ b/apps/src/lib.rs
@@ -68,10 +68,9 @@ impl AirplaneCoor {
                 if kilo_distance > MAX_RECEIVER_DISTANCE {
                     warn!("range: {kilo_distance} -  old: {lat_long:?} new: {test_position:?}");
                     return false;
-                } else {
-                    self.kilo_distance = Some(kilo_distance);
-                    debug!("range: {kilo_distance}");
                 }
+                self.kilo_distance = Some(kilo_distance);
+                debug!("range: {kilo_distance}");
             }
 
             // if previous position, check against for range. This is a non-great way of doing
@@ -81,9 +80,8 @@ impl AirplaneCoor {
                 if distance > MAX_AIRCRAFT_DISTANCE {
                     warn!("distance: {distance} old: {current_position:?}, invalid: {test_position:?}");
                     return false;
-                } else {
-                    debug!("distance: {distance}")
                 }
+                debug!("distance: {distance}");
             }
 
             // Good new position!
@@ -125,8 +123,10 @@ impl AirplaneCoor {
         let long1_rad = s.1.to_radians();
         let long2_rad = other.1.to_radians();
 
-        let a = ((lat2_rad - lat1_rad) / 2.00).sin().powf(2.00)
-            + lat1_rad.cos() * lat2_rad.cos() * ((long2_rad - long1_rad) / 2.00).sin().powf(2.00);
+        let a = ((lat2_rad - lat1_rad) / 2.00).sin().mul_add(
+            ((lat2_rad - lat1_rad) / 2.00).sin(),
+            lat1_rad.cos() * lat2_rad.cos() * ((long2_rad - long1_rad) / 2.00).sin().powi(2),
+        );
         let c = 2.00 * ((a).sqrt().atan2((1.00 - a).sqrt()));
         r * c
     }

--- a/apps/src/lib.rs
+++ b/apps/src/lib.rs
@@ -4,7 +4,13 @@ use std::time::SystemTime;
 
 use adsb_deku::adsb::{AirborneVelocity, Identification, ME};
 use adsb_deku::{cpr, Altitude, CPRFormat, Frame, DF, ICAO};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
+
+// Max distance from the receiver to the aircraft
+const MAX_RECEIVER_DISTANCE: f64 = 300.0;
+
+// Max obsurd distance an aircraft travelled between messages
+const MAX_AIRCRAFT_DISTANCE: f64 = 100.0;
 
 #[derive(Debug)]
 pub struct AirplaneState {
@@ -34,25 +40,63 @@ impl Default for AirplaneState {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct AirplaneCoor {
     /// [odd, even]
     pub altitudes: [Option<Altitude>; 2],
     /// lat/long
     pub position: Option<cpr::Position>,
+    /// last good time
+    pub last_time: Option<SystemTime>,
+    /// distance from receiver lat/long
+    pub kilo_distance: Option<f64>,
 }
 
 impl AirplaneCoor {
-    /// From Odd/Even Altitudes, update the position of aircraft
-    ///
-    /// TODO: verify position, such as `speed_test()`
-    fn update_position(&mut self) {
-        if let [Some(odd), Some(even)] = &self.altitudes {
-            self.position = cpr::get_position((odd, even));
-            if let Some(position) = &self.position {
-                debug!("update_position: odd: (lat: {}, long: {}), even: (lat: {}, long: {}), position: {:?}", odd.lat_cpr, odd.lon_cpr, even.lat_cpr, even.lat_cpr, position);
+    /// After checking the range of the new lat / long, new position from last position, update the
+    /// position of an aircraft
+    fn update_position(&mut self, lat_long: (f64, f64)) -> bool {
+        if let [Some(odd), Some(even)] = self.altitudes {
+            let test_position = cpr::get_position((&odd, &even));
+
+            // Check kilometer range from receiver
+            if let Some(test_position) = test_position {
+                let kilo_distance = Self::haversine_distance(
+                    lat_long,
+                    (test_position.latitude, test_position.longitude),
+                );
+                if kilo_distance > MAX_RECEIVER_DISTANCE {
+                    warn!("range: {kilo_distance} -  old: {lat_long:?} new: {test_position:?}");
+                    return false;
+                } else {
+                    self.kilo_distance = Some(kilo_distance);
+                    debug!("range: {kilo_distance}");
+                }
             }
+
+            // if previous position, check against for range. This is a non-great way of doing
+            // this, but maybe in the future we can check against the speed of the aircraft
+            if let (Some(current_position), Some(test_position)) = (self.position, test_position) {
+                let distance = Self::haversine_distance_position(current_position, test_position);
+                if distance > MAX_AIRCRAFT_DISTANCE {
+                    warn!("distance: {distance} old: {current_position:?}, invalid: {test_position:?}");
+                    return false;
+                } else {
+                    debug!("distance: {distance}")
+                }
+            }
+
+            // Good new position!
+            self.position = test_position;
+            debug!("update_position: odd: (lat: {}, long: {}), even: (lat: {}, long: {}), position: {:?}",
+                odd.lat_cpr,
+                odd.lon_cpr,
+                even.lat_cpr,
+                even.lat_cpr,
+                self.position);
+            self.last_time = Some(SystemTime::now());
         }
+        true
     }
 
     /// Return altitude from Odd Altitude
@@ -62,6 +106,30 @@ impl AirplaneCoor {
         }
         None
     }
+
+    /// Calculate the kilometers between two lat/long points
+    fn haversine_distance_position(position: cpr::Position, other: cpr::Position) -> f64 {
+        let lat1 = position.latitude;
+        let lat2 = other.latitude;
+        let long1 = position.longitude;
+        let long2 = other.longitude;
+        Self::haversine_distance((lat1, long1), (lat2, long2))
+    }
+
+    // https://en.wikipedia.org/wiki/Haversine_formula
+    fn haversine_distance(s: (f64, f64), other: (f64, f64)) -> f64 {
+        // kilometers
+        let r = 6371.00;
+        let lat1_rad = s.0.to_radians();
+        let lat2_rad = other.0.to_radians();
+        let long1_rad = s.1.to_radians();
+        let long2_rad = other.1.to_radians();
+
+        let a = ((lat2_rad - lat1_rad) / 2.00).sin().powf(2.00)
+            + lat1_rad.cos() * lat2_rad.cos() * ((long2_rad - long1_rad) / 2.00).sin().powf(2.00);
+        let c = 2.00 * ((a).sqrt().atan2((1.00 - a).sqrt()));
+        r * c
+    }
 }
 
 #[derive(Debug, Default)]
@@ -70,9 +138,9 @@ pub struct Airplanes(pub HashMap<ICAO, AirplaneState>);
 impl fmt::Display for Airplanes {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for key in self.0.keys() {
-            let value = self.lat_long_altitude(*key);
+            let value = self.aircraft_details(*key);
             if let Some(value) = value {
-                writeln!(f, "{}: {:?}", key, value)?;
+                writeln!(f, "{key}: {value:?}").unwrap();
             }
         }
         Ok(())
@@ -92,9 +160,8 @@ impl Airplanes {
         state.last_time = SystemTime::now();
     }
 
-    pub fn action(&mut self, frame: Frame) {
+    pub fn action(&mut self, frame: Frame, lat_long: (f64, f64)) {
         if let DF::ADSB(ref adsb) = frame.df {
-            self.incr_messages(adsb.icao);
             match &adsb.me {
                 ME::AircraftIdentification(identification) => {
                     self.add_identification(adsb.icao, identification);
@@ -104,10 +171,11 @@ impl Airplanes {
                 },
                 ME::AirbornePositionGNSSAltitude(altitude)
                 | ME::AirbornePositionBaroAltitude(altitude) => {
-                    self.add_altitude(adsb.icao, altitude);
+                    self.add_altitude(adsb.icao, altitude, lat_long);
                 },
                 _ => {},
             };
+            self.incr_messages(adsb.icao);
         }
     }
 
@@ -130,38 +198,41 @@ impl Airplanes {
     }
 
     /// Add `Altitude` from adsb frame
-    fn add_altitude(&mut self, icao: ICAO, altitude: &Altitude) {
+    fn add_altitude(&mut self, icao: ICAO, altitude: &Altitude, lat_long: (f64, f64)) {
         let state = self.0.entry(icao).or_insert_with(AirplaneState::default);
         info!(
             "[{icao}] with altitude: {}, cpr lat: {}, cpr long: {}",
             altitude.alt, altitude.lat_cpr, altitude.lon_cpr
         );
-        match altitude.odd_flag {
-            CPRFormat::Odd => {
-                state.coords = AirplaneCoor {
-                    altitudes: [state.coords.altitudes[0], Some(*altitude)],
-                    position: None,
-                };
+        let mut temp_coords = match altitude.odd_flag {
+            CPRFormat::Odd => AirplaneCoor {
+                altitudes: [state.coords.altitudes[0], Some(*altitude)],
+                ..state.coords
             },
-            CPRFormat::Even => {
-                state.coords = AirplaneCoor {
-                    altitudes: [Some(*altitude), state.coords.altitudes[1]],
-                    position: None,
-                };
+            CPRFormat::Even => AirplaneCoor {
+                altitudes: [Some(*altitude), state.coords.altitudes[1]],
+                ..state.coords
             },
+        };
+        // update the position from the new even/odd message if it's a good new position
+        if temp_coords.update_position(lat_long) {
+            state.coords = temp_coords;
+        } else {
+            // clear record
+            state.coords = AirplaneCoor::default();
         }
-        // updat the position from the new even/odd message
-        state.coords.update_position()
     }
 
-    /// return latitude, longitude and altitude of specific ICAO for airplane
+    // return display detail of aircraft
     #[must_use]
-    pub fn lat_long_altitude(&self, icao: ICAO) -> Option<(cpr::Position, u32)> {
+    pub fn aircraft_details(&self, icao: ICAO) -> Option<(cpr::Position, u32, f64)> {
         match self.0.get(&icao) {
             Some(airplane_state) => {
                 let coor = &airplane_state.coords;
-                if let (Some(position), Some(altitude)) = (&coor.position, coor.altitude()) {
-                    Some((position.clone(), altitude))
+                if let (Some(position), Some(altitude), Some(kilo_distance)) =
+                    (&coor.position, coor.altitude(), coor.kilo_distance)
+                {
+                    Some((*position, altitude, kilo_distance))
                 } else {
                     None
                 }
@@ -177,7 +248,7 @@ impl Airplanes {
         for (key, airplane_state) in &self.0 {
             let coor = &airplane_state.coords;
             if let Some(position) = &coor.position {
-                all_lat_long.push((position.clone(), *key));
+                all_lat_long.push((*position, *key));
             }
         }
 

--- a/apps/src/radar.rs
+++ b/apps/src/radar.rs
@@ -40,7 +40,7 @@ use crossterm::event::{
 use crossterm::terminal::enable_raw_mode;
 use crossterm::ExecutableCommand;
 use gpsd_proto::{get_data, handshake, ResponseData};
-use tracing::{error, debug, info, trace};
+use tracing::{debug, error, info, trace};
 use tracing_subscriber::EnvFilter;
 use tui::backend::{Backend, CrosstermBackend};
 use tui::layout::{Constraint, Direction, Layout, Rect};

--- a/apps/src/radar.rs
+++ b/apps/src/radar.rs
@@ -1,6 +1,6 @@
 //! This tui program displays the current ADS-B detected airplanes on a plot with your current
 //! position as (0,0) and has the ability to show different information about aircraft locations
-//! and testing your coverage.
+//! and testing your coverage.,
 //!
 //! # Tabs
 //!
@@ -40,7 +40,7 @@ use crossterm::event::{
 use crossterm::terminal::enable_raw_mode;
 use crossterm::ExecutableCommand;
 use gpsd_proto::{get_data, handshake, ResponseData};
-use tracing::{debug, info, trace};
+use tracing::{error, debug, info, trace};
 use tracing_subscriber::EnvFilter;
 use tui::backend::{Backend, CrosstermBackend};
 use tui::layout::{Constraint, Direction, Layout, Rect};
@@ -119,11 +119,15 @@ struct Opts {
     #[clap(long, default_value = "30002")]
     port: u16,
 
-    /// Antenna location latitude
+    /// Antenna location latitude, this use for aircraft position algorithms.
+    ///
+    /// This is overwritten when using the `--gpsd` option.
     #[clap(long)]
     lat: f64,
 
     /// Antenna location longitude
+    ///
+    /// This is overwritten when using the `--gpsd` option.
     #[clap(long)]
     long: f64,
 
@@ -139,7 +143,9 @@ struct Opts {
     #[clap(long, default_value = ".12")]
     scale: f64,
 
-    /// Enable automatic updating of lat/lon from gpsd(https://gpsd.io/) server
+    /// Enable automatic updating of lat/lon from gpsd(https://gpsd.io/) server.
+    ///
+    /// This overwrites the `--lat` and `--long`
     #[clap(long)]
     gpsd: bool,
 
@@ -148,7 +154,7 @@ struct Opts {
     gpsd_ip: String,
 
     /// Seconds since last message from airplane, triggers removal of airplane after time is up
-    #[clap(long, default_value = "10")]
+    #[clap(long, default_value = "30")]
     filter_time: u64,
 
     #[clap(long, default_value = "logs")]
@@ -158,7 +164,9 @@ struct Opts {
     #[clap(long)]
     touchscreen: bool,
 
-    /// Limit parsing of ADS-B messages to `DF::ADSB(17)` messages
+    /// Limit parsing of ADS-B messages to `DF::ADSB(17)` num_messages
+    ///
+    /// This can improve performance of just needing to read radar related messages
     #[clap(long)]
     limit_parsing: bool,
 }
@@ -195,16 +203,15 @@ struct Settings<'a> {
     lat: f64,
     /// current long from operator
     long: f64,
-    /// true: current lat/long differs from gpsd/cmdline input
-    /// false: user has changed lat/long with mouse/keyboard
-    custom_lat_lon: bool,
+    /// current lat from operator
+    custom_lat: Option<f64>,
+    /// current long from operator
+    custom_long: Option<f64>,
     /// last seen mouse clicking position
     last_mouse_dragging: Option<(u16, u16)>,
 }
 
 impl<'a> Settings<'a> {
-    // TODO: the Mutex::new() can be replaced with AtomicBool
-    #[allow(clippy::mutex_atomic)]
     fn new(opts: Opts) -> Self {
         Self {
             quit: None,
@@ -212,7 +219,8 @@ impl<'a> Settings<'a> {
             scale: opts.scale,
             lat: opts.lat,
             long: opts.long,
-            custom_lat_lon: false,
+            custom_lat: None,
+            custom_long: None,
             opts,
             last_mouse_dragging: None,
         }
@@ -229,7 +237,18 @@ impl<'a> Settings<'a> {
 
     /// Calculate mercator for local lat/long
     fn local_lat_lon(&self) -> (f64, f64) {
-        self.to_mercator(self.lat, self.long)
+        let lat = if let Some(lat) = self.custom_lat {
+            lat
+        } else {
+            self.lat
+        };
+
+        let long = if let Some(long) = self.custom_long {
+            long
+        } else {
+            self.long
+        };
+        self.to_mercator(lat, long)
     }
 
     /// Convert lat/long to mercator coordinates
@@ -258,34 +277,41 @@ impl<'a> Settings<'a> {
     }
 
     fn lat_increase(&mut self) {
-        self.lat += 0.005;
-        self.mutated();
+        if let Some(lat) = &mut self.custom_lat {
+            *lat += 0.005;
+        } else {
+            self.custom_lat = Some(self.lat + 0.005);
+        }
     }
 
     fn lat_decrease(&mut self) {
-        self.lat -= 0.005;
-        self.mutated();
+        if let Some(lat) = &mut self.custom_lat {
+            *lat -= 0.005;
+        } else {
+            self.custom_lat = Some(self.lat - 0.005);
+        }
     }
 
     fn long_increase(&mut self) {
-        self.long -= 0.03;
-        self.mutated();
+        if let Some(long) = &mut self.custom_long {
+            *long -= 0.03;
+        } else {
+            self.custom_long = Some(self.long - 0.03);
+        }
     }
 
     fn long_decrease(&mut self) {
-        self.long += 0.03;
-        self.mutated();
-    }
-
-    fn mutated(&mut self) {
-        self.custom_lat_lon = true;
+        if let Some(long) = &mut self.custom_long {
+            *long += 0.03;
+        } else {
+            self.custom_long = Some(self.long + 0.03);
+        }
     }
 
     fn reset(&mut self) {
-        self.lat = self.opts.lat;
-        self.long = self.opts.long;
+        self.custom_lat = None;
+        self.custom_long = None;
         self.scale = self.opts.scale;
-        self.custom_lat_lon = false;
     }
 }
 
@@ -405,13 +431,11 @@ see https://github.com/rsadsb/adsb_deku#serverdemodulationexternal-applications 
         }
         input.clear();
 
-        // if `--gpsd_ip` is selected, check if there is an update from that thread
-        if settings.opts.gpsd && !settings.custom_lat_lon {
-            if let Ok(lat_long) = gps_lat_long.lock() {
-                if let Some((lat, long)) = *lat_long {
-                    settings.lat = lat as f64;
-                    settings.long = long as f64;
-                }
+        // update lat/long from gpsd thread
+        if let Ok(lat_long) = gps_lat_long.lock() {
+            if let Some((lat, long)) = *lat_long {
+                settings.lat = lat as f64;
+                settings.long = long as f64;
             }
         }
 
@@ -446,9 +470,16 @@ see https://github.com/rsadsb/adsb_deku#serverdemodulationexternal-applications 
             };
             if df_adsb {
                 // parse the entire DF frame
-                if let Ok((_, frame)) = Frame::from_bytes((&bytes, 0)) {
-                    debug!("ADS-B Frame: {frame}");
-                    adsb_airplanes.action(frame);
+                let frame = Frame::from_bytes((&bytes, 0));
+                match frame {
+                    Ok((left_over, frame)) => {
+                        debug!("ADS-B Frame: {frame}");
+                        adsb_airplanes.action(frame, (settings.lat, settings.long));
+                        if left_over.1 != 0 {
+                            error!("{left_over:x?}");
+                        }
+                    },
+                    Err(e) => error!("{e:?}"),
                 }
             }
         }
@@ -598,10 +629,10 @@ fn handle_keyevent(
         (KeyCode::Enter, Tab::Airplanes) => {
             if let Some(selected) = airplanes_state.selected() {
                 let key = adsb_airplanes.0.keys().nth(selected).unwrap();
-                let pos = adsb_airplanes.lat_long_altitude(*key);
-                if let Some((position, _)) = pos {
-                    settings.lat = position.latitude;
-                    settings.long = position.longitude;
+                let pos = adsb_airplanes.aircraft_details(*key);
+                if let Some((position, _, _)) = pos {
+                    settings.custom_lat = Some(position.latitude);
+                    settings.custom_long = Some(position.longitude);
                     settings.tab_selection = Tab::Map;
                 }
             }
@@ -676,14 +707,21 @@ fn handle_mouseevent(mouse_event: MouseEvent, settings: &mut Settings, tui_info:
             if let Some((column, row)) = &settings.last_mouse_dragging {
                 let up =
                     f64::from(i32::from(mouse_event.row).wrapping_sub(i32::from(*row))) * 0.020;
-                settings.lat += up;
+                if let Some(lat) = &mut settings.custom_lat {
+                    *lat += up;
+                } else {
+                    settings.custom_lat = Some(settings.lat + up);
+                }
 
                 let left =
                     f64::from(i32::from(mouse_event.column).wrapping_sub(i32::from(*column)))
                         * 0.020;
-                settings.long -= left;
+                if let Some(long) = &mut settings.custom_long {
+                    *long -= left;
+                } else {
+                    settings.custom_long = Some(settings.long - left);
+                }
             }
-            settings.mutated();
             settings.last_mouse_dragging = Some((mouse_event.column, mouse_event.row));
         },
         MouseEventKind::Up(_) => {
@@ -722,16 +760,26 @@ fn draw(
                 .map(Spans::from)
                 .collect();
 
-            let view_type = if settings.custom_lat_lon {
-                "(CUSTOM)"
+            let mut view_type = "";
+
+            let lat = if let Some(lat) = settings.custom_lat {
+                view_type = "(CUSTOM)";
+                lat
             } else {
-                ""
+                settings.lat
+            };
+
+            let long = if let Some(long) = settings.custom_long {
+                view_type = "(CUSTOM)";
+                long
+            } else {
+                settings.long
             };
 
             let tab = Tabs::new(titles)
                 .block(
                     Block::default()
-                        .title(format!("({},{}) {view_type}", settings.lat, settings.long))
+                        .title(format!("({},{}) {view_type}", lat, long))
                         .borders(Borders::ALL),
                 )
                 .style(Style::default().fg(Color::White))
@@ -834,8 +882,8 @@ fn build_tab_map<A: tui::backend::Backend>(
 
             // draw ADSB tab airplanes
             for key in adsb_airplanes.0.keys() {
-                let value = adsb_airplanes.lat_long_altitude(*key);
-                if let Some((position, _altitude)) = value {
+                let value = adsb_airplanes.aircraft_details(*key);
+                if let Some((position, _, _)) = value {
                     let (x, y) = settings.to_xy(position.latitude, position.longitude);
 
                     // draw dot on location
@@ -918,13 +966,15 @@ fn build_tab_airplanes<A: tui::backend::Backend>(
     let empty = "".to_string();
     for key in adsb_airplanes.0.keys() {
         let state = adsb_airplanes.0.get(key).unwrap();
-        let pos = adsb_airplanes.lat_long_altitude(*key);
+        let pos = adsb_airplanes.aircraft_details(*key);
         let mut lat = empty.clone();
         let mut lon = empty.clone();
         let mut alt = empty.clone();
-        if let Some((position, altitude)) = pos {
+        let mut s_kilo_distance = empty.clone();
+        if let Some((position, altitude, kilo_distance)) = pos {
             lat = format!("{}", position.latitude);
             lon = format!("{}", position.longitude);
+            s_kilo_distance = format!("{}", kilo_distance);
             alt = format!("{altitude}");
         }
         rows.push(Row::new(vec![
@@ -939,6 +989,7 @@ fn build_tab_airplanes<A: tui::backend::Backend>(
             state
                 .speed
                 .map_or_else(|| "".into(), |v| format!("{v:>5.0}")),
+            format!("{:>8}", s_kilo_distance),
             format!("{:>8}", state.num_messages),
         ]));
     }
@@ -964,6 +1015,7 @@ fn build_tab_airplanes<A: tui::backend::Backend>(
                 "Altitude",
                 "   FPM",
                 "Speed",
+                "Distance",
                 "    Msgs",
             ])
             .bottom_margin(1),
@@ -982,6 +1034,7 @@ fn build_tab_airplanes<A: tui::backend::Backend>(
             Constraint::Length(6),
             Constraint::Length(5),
             Constraint::Length(8),
+            Constraint::Length(7),
         ])
         .column_spacing(1)
         .highlight_style(Style::default().add_modifier(Modifier::BOLD))

--- a/libadsb_deku/src/cpr.rs
+++ b/libadsb_deku/src/cpr.rs
@@ -16,7 +16,7 @@ const D_LAT_ODD: f64 = 360.0 / (4.0 * NZ - 1.0);
 const CPR_MAX: f64 = 131_072.0;
 
 /// Post-processing of CPR into Latitude/Longitude
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub struct Position {
     pub latitude: f64,
     pub longitude: f64,


### PR DESCRIPTION
Add range check from either the --lat and --long, or from --gpsd if
supplied. This limits the messages from being used in an aircrafts new
lat/long postion using the haversine distance from the reciever/operator
position.

Add distance check from the last aircraft position recorded. this
removes aircraft that are going physical impossible speeds based upon
the distance and the last time they were seen.

Add distance to Airplanes tab

Reduce time till dropped message to 30 seconds

Closes #21 