### PR TITLE
Fix typo, "quickstart"

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Decoder for [ADS-B(Automatic Dependent Surveillance-Broadcast)](https://en.wikipedia.org/wiki/Automatic_Dependent_Surveillance%E2%80%93Broadcast) Downlink Format protocol packets from 1090mhz. See [dump1090_rs](https://github.com/wcampbell0x2a/dump1090_rs.git) for a Rust demodulator. View planes in the sky around you, with only a [rtl-sdr](https://www.rtl-sdr.com/)!
 
-See [quistart-guide](https://rsadsb.github.io/quickstart.html) for a quick installation guide.
+See [quickstart-guide](https://rsadsb.github.io/quickstart.html) for a quick installation guide.
 
 See [rsadsb-blog](https://rsadsb.github.io/v0.5.0.html) for latest release details.
 


### PR DESCRIPTION
Noticed a small typo in the README.   'quistart' should be 'quickstart'