### PR TITLE
fix: terminal prints mouse escape codes after closing radar

### DIFF
--- a/apps/src/radar.rs
+++ b/apps/src/radar.rs
@@ -335,7 +335,11 @@ see https://github.com/rsadsb/adsb_deku#serverdemodulationexternal-applications 
         if let Some(reason) = settings.quit {
             terminal.clear()?;
             let mut stdout = io::stdout();
-            crossterm::execute!(stdout, crossterm::terminal::LeaveAlternateScreen)?;
+            crossterm::execute!(
+                stdout,
+                crossterm::terminal::LeaveAlternateScreen,
+                crossterm::event::DisableMouseCapture
+            )?;
             crossterm::terminal::disable_raw_mode()?;
             terminal.show_cursor()?;
             println!("radar: {}", reason);

--- a/apps/src/radar.rs
+++ b/apps/src/radar.rs
@@ -80,6 +80,7 @@ const TUI_START_MARGIN: u16 = 1;
 const TUI_BAR_WIDTH: u16 = 3;
 
 /// Available top row Tabs
+#[rustfmt::skip]
 #[derive(Copy, Clone)]
 enum Tab {
     Map       = 0,


### PR DESCRIPTION
After closing the program (with either `q` or `Control + C`) the terminal would print the mouse escape codes on all mouse movements (example below).
![mouse_bug](https://user-images.githubusercontent.com/22911290/156059270-d16f5f30-f222-4b45-b1e9-736000d614f0.png)

I was able to fix it by disabling mouse events capturing on program quit.

I think it fixes #116.


The other commit just adds a `#[rustfmt::skip]` attribute, as rustfmt didn't like the aligned equal signs in that enum and it would break them.