### PR TITLE
chore: remove rust fmt skip

### DIFF
--- a/apps/src/radar.rs
+++ b/apps/src/radar.rs
@@ -80,7 +80,6 @@ const TUI_START_MARGIN: u16 = 1;
 const TUI_BAR_WIDTH: u16 = 3;
 
 /// Available top row Tabs
-#[rustfmt::skip]
 #[derive(Copy, Clone)]
 enum Tab {
     Map       = 0,


### PR DESCRIPTION
I think this was caused by not running the nightly rust fmt