### PR TITLE
Add heading graphics to `Map` view

### DIFF
--- a/apps/src/cli.rs
+++ b/apps/src/cli.rs
@@ -146,7 +146,7 @@ mod tests {
             airports: None,
             airports_tz_filter: None,
             disable_icao: false,
-            show_heading: false,
+            disable_heading: false,
         };
         assert_eq!(exp_opt, opt);
 
@@ -187,7 +187,7 @@ mod tests {
             airports: None,
             airports_tz_filter: None,
             disable_icao: false,
-            show_heading: false,
+            disable_heading: false,
         };
         assert_eq!(exp_opt, opt);
     }

--- a/apps/src/cli.rs
+++ b/apps/src/cli.rs
@@ -73,6 +73,14 @@ pub struct Opts {
     #[clap(long)]
     pub disable_lat_long: bool,
 
+    /// Disable output of icao address of airplane
+    #[clap(long)]
+    pub disable_icao: bool,
+
+    /// Disbale display of angles on aircraft within Map display showing the direction of the aircraft.
+    #[clap(long)]
+    pub disable_heading: bool,
+
     /// Zoom level of Radar and Coverage (-=zoom out/+=zoom in)
     #[clap(long, default_value = ".12")]
     pub scale: f64,
@@ -111,10 +119,6 @@ pub struct Opts {
     /// comma seperated filter for --airports timezone data, such as: "America/Chicago,America/New_York"
     #[clap(long)]
     pub airports_tz_filter: Option<String>,
-
-    /// Disable output of icao address of airplane
-    #[clap(long)]
-    pub disable_icao: bool,
 }
 
 #[cfg(test)]
@@ -141,6 +145,8 @@ mod tests {
             limit_parsing: false,
             airports: None,
             airports_tz_filter: None,
+            disable_icao: false,
+            show_heading: false,
         };
         assert_eq!(exp_opt, opt);
 
@@ -180,6 +186,8 @@ mod tests {
             limit_parsing: false,
             airports: None,
             airports_tz_filter: None,
+            disable_icao: false,
+            show_heading: false,
         };
         assert_eq!(exp_opt, opt);
     }

--- a/apps/src/cli.rs
+++ b/apps/src/cli.rs
@@ -111,6 +111,10 @@ pub struct Opts {
     /// comma seperated filter for --airports timezone data, such as: "America/Chicago,America/New_York"
     #[clap(long)]
     pub airports_tz_filter: Option<String>,
+
+    /// Disable output of icao address of airplane
+    #[clap(long)]
+    pub disable_icao: bool,
 }
 
 #[cfg(test)]

--- a/apps/src/radar.rs
+++ b/apps/src/radar.rs
@@ -854,12 +854,14 @@ fn build_tab_map<A: tui::backend::Backend>(
                             .into_boxed_str()
                     };
 
-                    // draw plane ICAO name
-                    ctx.print(
-                        x,
-                        y,
-                        Span::styled(name.to_string(), Style::default().fg(Color::White)),
-                    );
+                    if !settings.opts.disable_icao {
+                        // draw plane ICAO name
+                        ctx.print(
+                            x,
+                            y + 20.0,
+                            Span::styled(name.to_string(), Style::default().fg(Color::White)),
+                        );
+                    }
                 }
             }
 

--- a/apps/src/radar.rs
+++ b/apps/src/radar.rs
@@ -844,12 +844,12 @@ fn build_tab_map<A: tui::backend::Backend>(
                     // draw dot on location
                     ctx.draw(&Points {
                         coords: &[(x, y)],
-                        color: Color::White,
+                        color: Color::Green,
                     });
 
-                    let heading = if let Some(heading) = heading {
-                        const ANGLE: f64 = 20.0;
-                        const LENGTH: f64 = 15.0;
+                    if let Some(heading) = heading {
+                        const ANGLE: f64 = 10.0;
+                        const LENGTH: f64 = 10.0;
 
                         let heading = heading + 180.0 % 360.0;
                         let n_heading = if heading > ANGLE {
@@ -861,26 +861,39 @@ fn build_tab_map<A: tui::backend::Backend>(
 
                         let (y_1, x_1) = {
                             (
+                                y + (2.0 * (n_heading.to_radians()).cos()),
+                                x + (2.0 * (n_heading.to_radians()).sin()),
+                            )
+                        };
+
+                        let (y_2, x_2) = {
+                            (
                                 y + (LENGTH * (n_heading.to_radians()).cos()),
                                 x + (LENGTH * (n_heading.to_radians()).sin()),
                             )
                         };
 
                         info!(heading);
-                        info!(x, y);
                         info!(x_1, y_1);
+                        info!(x_2, y_2);
 
                         // draw dot on location
                         ctx.draw(&Line {
-                            x1: x,
-                            x2: x_1,
-                            y1: y,
-                            y2: y_1,
+                            x1: x_1,
+                            x2: x_2,
+                            y1: y_1,
+                            y2: y_2,
                             color: Color::Blue,
                         });
 
                         let n_heading = (heading + ANGLE) % 360.0;
                         let (y_1, x_1) = {
+                            (
+                                y + (2.0 * (n_heading.to_radians()).cos()),
+                                x + (2.0 * (n_heading.to_radians()).sin()),
+                            )
+                        };
+                        let (y_2, x_2) = {
                             (
                                 y + (LENGTH * (n_heading.to_radians()).cos()),
                                 x + (LENGTH * (n_heading.to_radians()).sin()),
@@ -889,19 +902,16 @@ fn build_tab_map<A: tui::backend::Backend>(
 
                         // draw dot on location
                         ctx.draw(&Line {
-                            x1: x,
-                            x2: x_1,
-                            y1: y,
-                            y2: y_1,
+                            x1: x_1,
+                            x2: x_2,
+                            y1: y_1,
+                            y2: y_2,
                             color: Color::Blue,
                         });
-                        format!("{heading}")
-                    } else {
-                        "".to_string()
-                    };
+                    }
 
                     let name = if settings.opts.disable_lat_long {
-                        format!("{key} {heading}").into_boxed_str()
+                        format!("{key}").into_boxed_str()
                     } else {
                         format!("{key} ({}, {})", position.latitude, position.longitude)
                             .into_boxed_str()


### PR DESCRIPTION
* Add `heading` to Airplanes
* Add heading angles to aircraft in the `Map` view! Now you can correctly know what direction an aircraft is flying in!
* Add `--disable-icao` for **not** showing ICAO information for every aircraft
* Add `--disable-heading` for **not** showing the new heading angles

![2022-03-04-211117_846x615_scrot](https://user-images.githubusercontent.com/15236002/156865757-4787b1b4-4f52-4b59-a0f9-c1d0170febc1.png)
