### PR TITLE
feat: remove chrono crate and use time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,19 +148,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "time 0.1.44",
- "winapi",
-]
-
-[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,16 +600,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,13 +838,13 @@ version = "0.5.1"
 dependencies = [
  "adsb_deku",
  "anyhow",
- "chrono",
  "clap 3.1.0",
  "crossterm",
  "csv",
  "gpsd_proto",
  "hex",
  "serde",
+ "time",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -1093,17 +1070,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
@@ -1151,7 +1117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94571df2eae3ed4353815ea5a90974a594a1792d8782ff2cbcc9392d1101f366"
 dependencies = [
  "crossbeam-channel",
- "time 0.3.7",
+ "time",
  "tracing-subscriber",
 ]
 
@@ -1258,12 +1224,6 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -26,4 +26,4 @@ tracing-appender = "0.2"
 anyhow = { version = "1.0", features = ["backtrace"] }
 csv = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
-chrono = "0.4.19"
+time = { version = "0.3.7", features = ["local-offset"] }


### PR DESCRIPTION
Remove chrono, they seem to have no interest in fixing the issue from:
https://rustsec.org/advisories/RUSTSEC-2020-0071.html.

This defers that issue by using the time crate directly and using the
local_offset functions from a single thread. (This uses localtime_r
locally)