### PR TITLE
General updates

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -33,24 +33,24 @@ USAGE:
     radar [OPTIONS] --lat <LAT> --long <LONG>
 
 OPTIONS:
-        --airports <AIRPORTS>                        Import downloaded csv file for FAA Airport from
-                                                     https://github.com/mborsetti/airportsdata
-        --airports-tz-filter <AIRPORTS_TZ_FILTER>    comma seperated filter for --airports timezone data, such as:
-                                                     "America/Chicago,America/New_York"
-        --disable-lat-long                           Disable output of latitude and longitude on display
-        --filter-time <FILTER_TIME>                  Seconds since last message from airplane, triggers removal of airplane after time
-                                                     is up [default: 30]
+        --airports <AIRPORTS>                        Import downloaded csv file for FAA Airport from https://github.com/mborsetti/airportsdata
+        --airports-tz-filter <AIRPORTS_TZ_FILTER>    comma seperated filter for --airports timezone data, such as: "America/Chicago,America/New_York"
+        --disable-heading                            Disable display of angles on aircraft within Map display showing the direction of the aircraft
+        --disable-icao                               Disable output of icao address of airplane on Map
+        --disable-lat-long                           Disable output of latitude and longitude on Map
+        --disable-track                              Disable display of previous positions of aircraft on Map
+        --filter-time <FILTER_TIME>                  Seconds since last message from airplane, triggers removal of airplane after time is up [default: 120]
         --gpsd                                       Enable automatic updating of lat/lon from gpsd(https://gpsd.io/) server
         --gpsd-ip <GPSD_IP>                          Ip address of gpsd [default: localhost]
     -h, --help                                       Print help information
         --host <HOST>                                ip address / hostname of ADS-B server / demodulator [default: 127.0.0.1]
         --lat <LAT>                                  Antenna location latitude, this use for aircraft position algorithms
         --limit-parsing                              Limit parsing of ADS-B messages to `DF::ADSB(17)` num_messages
-        --locations <LOCATIONS>...                   Vector of location [(name, lat, long),..]
+        --locations <LOCATIONS>...                   Vector of location [(name, lat, long),..] to display on Map
         --log-folder <LOG_FOLDER>                    [default: logs]
         --long <LONG>                                Antenna location longitude
         --port <PORT>                                port of ADS-B server / demodulator [default: 30002]
-        --scale <SCALE>                              Zoom level of Radar and Coverage (-=zoom out/+=zoom in) [default: .12]
+        --scale <SCALE>                              Zoom level of Map and Coverage (-=zoom out/+=zoom in) [default: .12]
         --touchscreen                                Enable three tabs on left side of screen for zoom out/zoom in/and reset
     -V, --version                                    Print version information
 

--- a/apps/src/airport.rs
+++ b/apps/src/airport.rs
@@ -17,13 +17,13 @@ pub struct Airport {
 }
 
 impl Airport {
-    pub fn from_file(filename: &str, time_zones: &Option<String>) -> Vec<Airport> {
+    pub fn from_file(filename: &str, time_zones: &Option<String>) -> Vec<Self> {
         let mut airports = vec![];
         let f = File::open(filename).unwrap();
 
         let mut rdr = csv::Reader::from_reader(f);
         for result in rdr.deserialize() {
-            let record: Airport = result.unwrap();
+            let record: Self = result.unwrap();
 
             if let Some(ref time_zones) = time_zones {
                 for tz in time_zones.split(',') {

--- a/apps/src/radar.rs
+++ b/apps/src/radar.rs
@@ -47,7 +47,7 @@ mod scale {
     pub const CHANGE: f64 = 1.1;
 
     /// Value used as mutiplier in map scaling for projection
-    pub const DEFAULT: f64 = 500000.0;
+    pub const DEFAULT: f64 = 500_000.0;
 }
 
 /// Accuracy of latitude/longitude for Coverage is affected by this variable.
@@ -878,12 +878,12 @@ fn build_tab_map<A: tui::backend::Backend>(
 
                             // move the first point out, so that the green point of the aircraft
                             // _usually_ shows.
-                            let y_1 = y + (2.0 * (n_heading.to_radians()).cos()) as f64;
-                            let x_1 = x + (2.0 * (n_heading.to_radians()).sin()) as f64;
+                            let y_1 = y + f64::from(2.0 * (n_heading.to_radians()).cos());
+                            let x_1 = x + f64::from(2.0 * (n_heading.to_radians()).sin());
 
                             // draw the line out from the aircraft at an angle
-                            let y_2 = y + (LENGTH * (n_heading.to_radians()).cos()) as f64;
-                            let x_2 = x + (LENGTH * (n_heading.to_radians()).sin()) as f64;
+                            let y_2 = y + f64::from(LENGTH * (n_heading.to_radians()).cos());
+                            let x_2 = x + f64::from(LENGTH * (n_heading.to_radians()).sin());
 
                             ctx.draw(&Line {
                                 x1: x_1,
@@ -895,10 +895,10 @@ fn build_tab_map<A: tui::backend::Backend>(
 
                             // repeat for the other side (addition, so just modding)
                             let n_heading = (heading + angle) % 360.0;
-                            let y_1 = y + (2.0 * (n_heading.to_radians()).cos()) as f64;
-                            let x_1 = x + (2.0 * (n_heading.to_radians()).sin()) as f64;
-                            let y_2 = y + (LENGTH * (n_heading.to_radians()).cos()) as f64;
-                            let x_2 = x + (LENGTH * (n_heading.to_radians()).sin()) as f64;
+                            let y_1 = y + f64::from(2.0 * (n_heading.to_radians()).cos());
+                            let x_1 = x + f64::from(2.0 * (n_heading.to_radians()).sin());
+                            let y_2 = y + f64::from(LENGTH * (n_heading.to_radians()).cos());
+                            let x_2 = x + f64::from(LENGTH * (n_heading.to_radians()).sin());
 
                             ctx.draw(&Line {
                                 x1: x_1,
@@ -1281,7 +1281,7 @@ fn draw_locations(ctx: &mut tui::widgets::canvas::Context<'_>, settings: &Settin
     }
 }
 
-/// function ran withint a thread for updating `gps_lat_long` when the gpsd shows a new lat_long
+/// function ran withint a thread for updating `gps_lat_long` when the gpsd shows a new `lat_long`
 /// position.
 fn gpsd_thread(gpsd_ip: String, gps_lat_long: Arc<Mutex<Option<(f64, f64)>>>) {
     let gpsd_port = 2947;

--- a/apps/src/radar.rs
+++ b/apps/src/radar.rs
@@ -862,11 +862,11 @@ fn build_tab_map<A: tui::backend::Backend>(
                     // add degrees of the angle before displaying
                     if !settings.opts.disable_heading {
                         if let Some(heading) = heading {
-                            const ANGLE: f64 = 20.0;
-                            const LENGTH: f64 = 8.0;
+                            const ANGLE: f32 = 20.0;
+                            const LENGTH: f32 = 8.0;
 
                             let addition_heading = (heading % 90.0) / 10.0;
-                            let angle: f64 = ANGLE + addition_heading;
+                            let angle: f32 = ANGLE + addition_heading;
 
                             let heading = heading + 180.0 % 360.0;
                             // wrap around the angle since we are are subtracting
@@ -878,12 +878,12 @@ fn build_tab_map<A: tui::backend::Backend>(
 
                             // move the first point out, so that the green point of the aircraft
                             // _usually_ shows.
-                            let y_1 = y + (2.0 * (n_heading.to_radians()).cos());
-                            let x_1 = x + (2.0 * (n_heading.to_radians()).sin());
+                            let y_1 = y + (2.0 * (n_heading.to_radians()).cos()) as f64;
+                            let x_1 = x + (2.0 * (n_heading.to_radians()).sin()) as f64;
 
                             // draw the line out from the aircraft at an angle
-                            let y_2 = y + (LENGTH * (n_heading.to_radians()).cos());
-                            let x_2 = x + (LENGTH * (n_heading.to_radians()).sin());
+                            let y_2 = y + (LENGTH * (n_heading.to_radians()).cos()) as f64;
+                            let x_2 = x + (LENGTH * (n_heading.to_radians()).sin()) as f64;
 
                             ctx.draw(&Line {
                                 x1: x_1,
@@ -895,10 +895,10 @@ fn build_tab_map<A: tui::backend::Backend>(
 
                             // repeat for the other side (addition, so just modding)
                             let n_heading = (heading + angle) % 360.0;
-                            let y_1 = y + (2.0 * (n_heading.to_radians()).cos());
-                            let x_1 = x + (2.0 * (n_heading.to_radians()).sin());
-                            let y_2 = y + (LENGTH * (n_heading.to_radians()).cos());
-                            let x_2 = x + (LENGTH * (n_heading.to_radians()).sin());
+                            let y_1 = y + (2.0 * (n_heading.to_radians()).cos()) as f64;
+                            let x_1 = x + (2.0 * (n_heading.to_radians()).sin()) as f64;
+                            let y_2 = y + (LENGTH * (n_heading.to_radians()).cos()) as f64;
+                            let x_2 = x + (LENGTH * (n_heading.to_radians()).sin()) as f64;
 
                             ctx.draw(&Line {
                                 x1: x_1,

--- a/ensure_no_std/Cargo.lock
+++ b/ensure_no_std/Cargo.lock
@@ -71,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "deku"
-version = "0.12.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6636cb8b0811013ab93bc37b88b460ca637ce3bdc97fb68ca79d7d7df4f16cba"
+checksum = "532b5c81bae1d2b6f251de3918d2511cb927f63c990ab3befbf680f6654953ae"
 dependencies = [
  "bitvec",
  "deku_derive",
@@ -81,9 +81,9 @@ dependencies = [
 
 [[package]]
 name = "deku_derive"
-version = "0.12.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bf7f0f5c5d6b9cc189dea2a0fece14c26a0bbb9df7b52d2fe7b6dd300dae1a0"
+checksum = "3c4bbb40beff5b368edf0127a546c608f83462c31ccfab05d5f0f1f0457e7b16"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/ensure_no_std/src/bin/main.rs
+++ b/ensure_no_std/src/bin/main.rs
@@ -5,10 +5,10 @@
 #![no_main]
 #![feature(core_intrinsics, lang_items, alloc_error_handler)]
 
-use adsb_deku::Frame;
 use adsb_deku::deku::DekuContainerRead;
-use rsadsb_common::Airplanes;
+use adsb_deku::Frame;
 use hexlit::hex;
+use rsadsb_common::Airplanes;
 
 extern crate alloc;
 extern crate wee_alloc;
@@ -43,7 +43,7 @@ unsafe fn oom(_: ::core::alloc::Layout) -> ! {
 extern "C" fn eh_personality() {}
 
 #[no_mangle]
-pub extern "C" fn main() -> () {
+pub extern "C" fn main() {
     let buffer = hex!("8da7c32758ab75f3291315f10261");
     let _ = Frame::from_bytes((&buffer, 0)).unwrap().0;
     let _ = Airplanes::new();

--- a/libadsb_deku/src/adsb.rs
+++ b/libadsb_deku/src/adsb.rs
@@ -751,26 +751,10 @@ impl fmt::Display for ControlFieldType {
         let s_type = match self {
             Self::ADSB_ES_NT | Self::ADSB_ES_NT_ALT => "(ADS-B)",
             Self::TISB_COARSE | Self::TISB_ADSB_RELAY | Self::TISB_FINE => "(TIS-B)",
-            Self::TISB_MANAGE => "(ADS-R)",
-            Self::TISB_ADSB => "(ADS-R)",
+            Self::TISB_MANAGE | Self::TISB_ADSB => "(ADS-R)",
             Self::Reserved => "(unknown addressing scheme)",
         };
         write!(f, "{s_type}")
-    }
-}
-
-/// [`crate::DF::TisB`] Containing ICAO
-
-#[derive(Debug, PartialEq, DekuRead, Copy, Clone)]
-#[deku(type = "u8", bits = "1")]
-pub enum Unit {
-    Meter = 0,
-    Feet  = 1,
-}
-
-impl Default for Unit {
-    fn default() -> Self {
-        Self::Meter
     }
 }
 

--- a/libadsb_deku/src/adsb.rs
+++ b/libadsb_deku/src/adsb.rs
@@ -170,7 +170,7 @@ impl ME {
                     if let Some((heading, ground_speed, vertical_rate)) =
                         airborne_velocity.calculate()
                     {
-                        writeln!(f, "  Heading:       {}", libm::ceil(heading))?;
+                        writeln!(f, "  Heading:       {}", libm::ceil(heading as f64))?;
                         writeln!(
                             f,
                             "  Speed:         {} kt groundspeed",
@@ -903,7 +903,7 @@ pub struct TargetStateAndStatusInformation {
     #[deku(
         bits = "9",
         endian = "big",
-        map = "|heading: u32| -> Result<_, DekuError> {Ok(heading as f32 * 180.0 / 256.0)}"
+        map = "|heading: u16| -> Result<_, DekuError> {Ok(heading as f32 * 180.0 / 256.0)}"
     )]
     pub heading: f32,
     #[deku(bits = "4")]
@@ -956,9 +956,9 @@ pub struct AirborneVelocity {
 }
 
 impl AirborneVelocity {
-    /// Return effective (heading, `ground_speed`, `vertical_rate`) for groundspeed
+    /// Return effective (`heading`, `ground_speed`, `vertical_rate`) for groundspeed
     #[must_use]
-    pub fn calculate(&self) -> Option<(f64, f64, i16)> {
+    pub fn calculate(&self) -> Option<(f32, f64, i16)> {
         if let AirborneVelocitySubType::GroundSpeedDecoding(ground_speed) = &self.sub_type {
             let v_ew = f64::from((ground_speed.ew_vel as i16 - 1) * ground_speed.ew_sign.value());
             let v_ns = f64::from((ground_speed.ns_vel as i16 - 1) * ground_speed.ns_sign.value());
@@ -972,7 +972,7 @@ impl AirborneVelocity {
                 .map(|v| (v as i16) * self.vrate_sign.value());
 
             if let Some(vrate) = vrate {
-                return Some((heading, libm::hypot(v_ew, v_ns), vrate));
+                return Some((heading as f32, libm::hypot(v_ew, v_ns), vrate));
             }
         }
         None

--- a/libadsb_deku/src/adsb.rs
+++ b/libadsb_deku/src/adsb.rs
@@ -10,7 +10,6 @@ use core::{
     clone::Clone,
     cmp::PartialEq,
     convert::From,
-    default::Default,
     f64,
     fmt::Write,
     fmt::{Debug, Error},

--- a/libadsb_deku/src/lib.rs
+++ b/libadsb_deku/src/lib.rs
@@ -698,7 +698,9 @@ impl fmt::Display for FlightStatus {
             f,
             "{}",
             match self {
-                Self::NoAlertNoSPIAirborne | Self::AlertSPIAirborneGround | Self::NoAlertSPIAirborneGround => "airborne?",
+                Self::NoAlertNoSPIAirborne
+                | Self::AlertSPIAirborneGround
+                | Self::NoAlertSPIAirborneGround => "airborne?",
                 Self::NoAlertNoSPIOnGround => "ground?",
                 Self::AlertNoSPIAirborne => "airborne",
                 Self::AlertNoSPIOnGround => "ground",

--- a/libadsb_deku/src/lib.rs
+++ b/libadsb_deku/src/lib.rs
@@ -698,12 +698,10 @@ impl fmt::Display for FlightStatus {
             f,
             "{}",
             match self {
-                Self::NoAlertNoSPIAirborne => "airborne?",
+                Self::NoAlertNoSPIAirborne | Self::AlertSPIAirborneGround | Self::NoAlertSPIAirborneGround => "airborne?",
                 Self::NoAlertNoSPIOnGround => "ground?",
                 Self::AlertNoSPIAirborne => "airborne",
                 Self::AlertNoSPIOnGround => "ground",
-                Self::AlertSPIAirborneGround => "airborne?",
-                Self::NoAlertSPIAirborneGround => "airborne?",
                 _ => "reserved",
             }
         )
@@ -771,12 +769,12 @@ impl fmt::Display for Capability {
             f,
             "{}",
             match self {
-                Capability::AG_UNCERTAIN => "uncertain1",
-                Capability::Reserved => "reserved",
-                Capability::AG_GROUND => "ground",
-                Capability::AG_AIRBORNE => "airborne",
-                Capability::AG_UNCERTAIN2 => "uncertain2",
-                Capability::AG_UNCERTAIN3 => "airborne?",
+                Self::AG_UNCERTAIN => "uncertain1",
+                Self::Reserved => "reserved",
+                Self::AG_GROUND => "ground",
+                Self::AG_AIRBORNE => "airborne",
+                Self::AG_UNCERTAIN2 => "uncertain2",
+                Self::AG_UNCERTAIN3 => "airborne?",
             }
         )
     }

--- a/libadsb_deku/src/lib.rs
+++ b/libadsb_deku/src/lib.rs
@@ -125,7 +125,7 @@ pub use deku;
 extern crate alloc;
 
 #[cfg(feature = "alloc")]
-use alloc::{fmt, format, string::String, vec, vec::Vec};
+use alloc::{fmt, format, string::String, string::ToString, vec, vec::Vec};
 #[cfg(feature = "alloc")]
 use core::{
     clone::Clone,
@@ -465,7 +465,7 @@ pub struct Altitude {
     #[deku(bits = "1")]
     pub saf_or_imf: u8,
     #[deku(reader = "Self::read(deku::rest)")]
-    pub alt: u32,
+    pub alt: Option<u16>,
     /// UTC sync or not
     #[deku(bits = "1")]
     pub t: bool,
@@ -479,7 +479,12 @@ pub struct Altitude {
 
 impl fmt::Display for Altitude {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "  Altitude:      {} ft barometric", self.alt)?;
+        let altitude = if let Some(altitude) = self.alt {
+            format!("{} ft barometric", altitude)
+        } else {
+            "None".to_string()
+        };
+        writeln!(f, "  Altitude:      {}", altitude)?;
         writeln!(f, "  CPR type:      Airborne")?;
         writeln!(f, "  CPR odd flag:  {}", self.odd_flag)?;
         writeln!(f, "  CPR latitude:  ({})", self.lat_cpr)?;
@@ -490,7 +495,9 @@ impl fmt::Display for Altitude {
 
 impl Altitude {
     /// `decodeAC12Field`
-    fn read(rest: &BitSlice<Msb0, u8>) -> result::Result<(&BitSlice<Msb0, u8>, u32), DekuError> {
+    fn read(
+        rest: &BitSlice<Msb0, u8>,
+    ) -> result::Result<(&BitSlice<Msb0, u8>, Option<u16>), DekuError> {
         let (rest, num) = u32::read(rest, (deku::ctx::Endian::Big, deku::ctx::Size::Bits(12)))?;
 
         let q = num & 0x10;
@@ -499,17 +506,18 @@ impl Altitude {
             let n = ((num & 0x0fe0) >> 1) | (num & 0x000f);
             let n = n * 25;
             if n > 1000 {
-                Ok((rest, (n - 1000) as u32))
+                // TODO: maybe replace with Result->Option
+                Ok((rest, u16::try_from(n - 1000).ok()))
             } else {
-                Ok((rest, 0))
+                Ok((rest, None))
             }
         } else {
             let mut n = ((num & 0x0fc0) << 1) | (num & 0x003f);
             n = mode_ac::decode_id13_field(n);
             if let Ok(n) = mode_ac::mode_a_to_mode_c(n) {
-                Ok((rest, ((n as u32) * 100)))
+                Ok((rest, u16::try_from(n * 100).ok()))
             } else {
-                Ok((rest, (0)))
+                Ok((rest, None))
             }
         }
     }
@@ -704,11 +712,11 @@ impl fmt::Display for FlightStatus {
 
 /// 13 bit encoded altitude
 #[derive(Debug, PartialEq, DekuRead, Copy, Clone)]
-pub struct AC13Field(#[deku(reader = "Self::read(deku::rest)")] pub u32);
+pub struct AC13Field(#[deku(reader = "Self::read(deku::rest)")] pub u16);
 
 impl AC13Field {
     // TODO Add unit
-    fn read(rest: &BitSlice<Msb0, u8>) -> result::Result<(&BitSlice<Msb0, u8>, u32), DekuError> {
+    fn read(rest: &BitSlice<Msb0, u8>) -> result::Result<(&BitSlice<Msb0, u8>, u16), DekuError> {
         let (rest, num) = u32::read(rest, (deku::ctx::Endian::Big, deku::ctx::Size::Bits(13)))?;
 
         let m_bit = num & 0x0040;
@@ -721,7 +729,7 @@ impl AC13Field {
             let n = ((num & 0x1f80) >> 2) | ((num & 0x0020) >> 1) | (num & 0x000f);
             let n = n as u32 * 25;
             if n > 1000 {
-                Ok((rest, n - 1000))
+                Ok((rest, (n - 1000) as u16))
             } else {
                 // TODO: add error
                 Ok((rest, 0))
@@ -729,7 +737,7 @@ impl AC13Field {
         } else {
             // TODO 11 bit gillham coded altitude
             if let Ok(n) = mode_ac::mode_a_to_mode_c(mode_ac::decode_id13_field(num)) {
-                Ok((rest, (100 * n)))
+                Ok((rest, (100 * n) as u16))
             } else {
                 Ok((rest, 0))
             }

--- a/libadsb_deku/tests/test.rs
+++ b/libadsb_deku/tests/test.rs
@@ -29,7 +29,7 @@ fn testing02() {
     if let DF::ADSB(adsb) = frame.unwrap().1.df {
         if let ME::AirborneVelocity(me) = adsb.me {
             let (heading, ground_speed, vertical_rate) = me.calculate().unwrap();
-            assert!((heading - 322.197_207_549_061_5).abs() < f32::EPSILON);
+            assert!((heading - 322.197_2).abs() < f32::EPSILON);
             assert!((ground_speed - 417.655_360_315_176_6).abs() < f64::EPSILON);
             assert_eq!(vertical_rate, 0);
             assert_eq!(me.vrate_src, VerticalRateSource::GeometricAltitude);

--- a/libadsb_deku/tests/test.rs
+++ b/libadsb_deku/tests/test.rs
@@ -11,7 +11,7 @@ fn testing01() {
     let frame = Frame::from_bytes((&bytes, 0));
     if let DF::ADSB(adsb) = frame.unwrap().1.df {
         if let ME::AirbornePositionBaroAltitude(me) = adsb.me {
-            assert_eq!(me.alt, 38000);
+            assert_eq!(me.alt, Some(38000));
             assert_eq!(me.lat_cpr, 93000);
             assert_eq!(me.lon_cpr, 51372);
             assert_eq!(me.odd_flag, CPRFormat::Even);
@@ -29,7 +29,7 @@ fn testing02() {
     if let DF::ADSB(adsb) = frame.unwrap().1.df {
         if let ME::AirborneVelocity(me) = adsb.me {
             let (heading, ground_speed, vertical_rate) = me.calculate().unwrap();
-            assert!((heading - 322.197_207_549_061_5).abs() < f64::EPSILON);
+            assert!((heading - 322.197_207_549_061_5).abs() < f32::EPSILON);
             assert!((ground_speed - 417.655_360_315_176_6).abs() < f64::EPSILON);
             assert_eq!(vertical_rate, 0);
             assert_eq!(me.vrate_src, VerticalRateSource::GeometricAltitude);

--- a/rsadsb_common/src/lib.rs
+++ b/rsadsb_common/src/lib.rs
@@ -202,7 +202,7 @@ impl Airplanes {
                 heading, ground_speed, vert_speed
             );
             state.heading = Some(heading);
-            state.speed = Some(ground_speed);
+            state.speed = Some(ground_speed as f32);
             state.vert_speed = Some(vert_speed);
         }
     }
@@ -211,7 +211,7 @@ impl Airplanes {
     fn add_altitude(&mut self, icao: ICAO, altitude: &Altitude, lat_long: (f64, f64)) {
         let state = self.0.entry(icao).or_insert_with(AirplaneState::default);
         info!(
-            "[{icao}] with altitude: {}, cpr lat: {}, cpr long: {}",
+            "[{icao}] with altitude: {:?}, cpr lat: {}, cpr long: {}",
             altitude.alt, altitude.lat_cpr, altitude.lon_cpr
         );
         let mut temp_coords = match altitude.odd_flag {
@@ -248,9 +248,9 @@ impl Airplanes {
 #[derive(Debug)]
 pub struct AirplaneDetails {
     pub position: cpr::Position,
-    pub altitude: u32,
+    pub altitude: u16,
     pub kilo_distance: f64,
-    pub heading: Option<f64>,
+    pub heading: Option<f32>,
     pub track: Option<Vec<AirplaneCoor>>,
 }
 
@@ -265,13 +265,15 @@ pub struct AirplaneState {
     ///
     /// 0 = Straight up
     /// 90 = Right, and so on
-    pub heading: Option<f64>,
-    /// speed from `adsb::AirborneVelocity::calculate()`
-    pub speed: Option<f64>,
+    pub heading: Option<f32>,
+    /// ground_speed from `adsb::AirborneVelocity::calculate()`
+    ///
+    /// Stored as a f64 in that library but we store as f32 for size reasons in this library
+    pub speed: Option<f32>,
     /// vert_speed from `adsb::AirborneVelocity::calculate()`
     pub vert_speed: Option<i16>,
     pub on_ground: Option<bool>,
-    pub num_messages: u64,
+    pub num_messages: u32,
     #[cfg(feature = "std")]
     pub last_time: SystemTime,
     pub track: Option<Vec<AirplaneCoor>>,
@@ -357,9 +359,11 @@ impl AirplaneCoor {
     }
 
     /// Return altitude from Odd Altitude
-    fn altitude(&self) -> Option<u32> {
+    fn altitude(&self) -> Option<u16> {
         if let Some(odd) = self.altitudes[0] {
-            return Some(odd.alt);
+            if let Some(alt) = odd.alt {
+                return Some(alt);
+            }
         }
         None
     }

--- a/rsadsb_common/src/lib.rs
+++ b/rsadsb_common/src/lib.rs
@@ -388,10 +388,12 @@ impl AirplaneCoor {
         let x_lat = libm::sin((lat2_rad - lat1_rad) / 2.00);
         let x_long = libm::sin((long2_rad - long1_rad) / 2.00);
 
+        // this clippy lint will dis-allow mul_add, this isn't available for `no_std`
+        #[allow(clippy::suboptimal_flops)]
         let a = x_lat * x_lat
             + libm::cos(lat1_rad)
                 * libm::cos(lat2_rad)
-                * libm::powf(libm::sin(x_long) as f32, 2.0) as f64;
+                * f64::from(libm::powf(libm::sin(x_long) as f32, 2.0));
 
         let c = 2.0 * libm::atan2(libm::sqrt(a), libm::sqrt(1.0 - a));
 


### PR DESCRIPTION
Reduce the size of types to reduce memory usage of application and
library for embeded environs.

struct Altitude::alt has been changed to an Option<u16>. The change from
u32 to u16 was done for size reasons, and a normal operating altitude is
lower then the max u16. The Option was to fix the function returning 0
when it's actually a very invalid altitude.

AC13Field altitude was changed to a u16, this isn't usually a user
facing struct.

In libadsb_common, AirplaneDetails altitude was changed to u16, heading
was changed to f32. num_messages was changed to u32.