### PR TITLE
Add --retry-tcp for retry for dump1090 connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Stats Tab, with `Max Distance` and `Most Airplanes`.
 - Fixed terminal escape codes for mouse control. Thanks ([@paunstefan](https://github.com/paunstefan)) ([!124](https://github.com/rsadsb/adsb_deku/pull/124))
 - Reduce precision of all `f32`s to 3. (for longitude, latitude, heading displays).
+- Add `--retry-tcp` for trying to connect to a dump1090 instance if it crashes.
 
 ### 1090
 - feat: Release binary is now stripped. ~1.2MB -> 440KB. MSRV is bumped to `1.59`.

--- a/apps/src/cli.rs
+++ b/apps/src/cli.rs
@@ -156,6 +156,7 @@ mod tests {
             disable_icao: false,
             disable_heading: false,
             disable_track: false,
+            retry_tcp: false,
         };
         assert_eq!(exp_opt, opt);
 
@@ -198,6 +199,7 @@ mod tests {
             disable_icao: false,
             disable_heading: false,
             disable_track: false,
+            retry_tcp: false,
         };
         assert_eq!(exp_opt, opt);
     }

--- a/apps/src/cli.rs
+++ b/apps/src/cli.rs
@@ -123,6 +123,10 @@ pub struct Opts {
     /// comma seperated filter for --airports timezone data, such as: "America/Chicago,America/New_York"
     #[clap(long)]
     pub airports_tz_filter: Option<String>,
+
+    /// retry TCP connection to dump1090 instance if connecton is lost/disconnected
+    #[clap(long)]
+    pub retry_tcp: bool,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Add --retry-tcp for connecting to a dump1090 instance if that service
goes down.

The init_tcp_reader is used for the initial connection, which adds a tui
display for waiting for the connection which is nice. This same tui
display is shown when the server goes down and we try again.

QuitReason has been added for some better exit reasons