### PR TITLE
Remove features in apps/

### DIFF
--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -13,11 +13,6 @@ path = "src/radar.rs"
 name = "1090"
 path = "src/1090.rs"
 
-[features]
-default = ["std"]
-std = ["adsb_deku/std", "alloc"]
-alloc = ["adsb_deku/alloc"]
-
 [dependencies]
 adsb_deku = { path = "../libadsb_deku", version = "0.5" }
 rsadsb_common = { path = "../rsadsb_common", version = "0.5" }


### PR DESCRIPTION
Remove features that are enabled by default in adsb_deku when std and
alloc are enabled by default and is always enabled in apps/