### PR TITLE
Add total airplanes tracked to Stats page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    - `Heading`: Display an arrow to show the direction of the tracked aircraft. Use key: `h` to turn off, or 
      `--disable-heading` cli option.
 - Add key: `i` to trigger disable of ICAO names above aircraft positions.
-- Add Stats Tab, with `Max Distance` and `Most Airplanes`.
+- Add Stats Tab, with `Max Distance`, `Most Airplanes`, and `Total Airplanes Tracked`.
 - Fix terminal escape codes for mouse control. Thanks ([@paunstefan](https://github.com/paunstefan)) ([!124](https://github.com/rsadsb/adsb_deku/pull/124)).
 - Reduce precision of all `f32`s to 3. (for longitude, latitude, heading displays).
 - Add `--retry-tcp` for trying to connect to a dump1090 instance if it crashes. Add tui screen to alert user instead of crashing.

--- a/apps/src/radar/stats.rs
+++ b/apps/src/radar/stats.rs
@@ -1,8 +1,56 @@
+use std::time::SystemTime;
+
+use adsb_deku::ICAO;
+use rsadsb_common::{Added, AirplaneCoor, Airplanes};
+use tracing::info;
 use tui::layout::{Constraint, Rect};
 use tui::style::{Color, Style};
 use tui::widgets::{Block, Borders, Row, Table};
 
-use crate::{Settings, Stats, DEFAULT_PRECISION};
+use crate::{Settings, DEFAULT_PRECISION};
+
+#[derive(Debug, Default)]
+pub struct Stats {
+    most_distance: Option<(SystemTime, ICAO, AirplaneCoor)>,
+    most_airplanes: Option<(SystemTime, u32)>,
+    total_airplanes: u32,
+}
+
+impl Stats {
+    pub fn update(&mut self, airplanes: &Airplanes, airplane_added: Added) {
+        // Update most_distance
+        let current_distance = self.most_distance.map_or(0.0, |most_distance| {
+            most_distance
+                .2
+                .kilo_distance
+                .map_or(0.0, |kilo_distance| kilo_distance)
+        });
+        for (key, state) in airplanes.iter() {
+            if let Some(distance) = state.coords.kilo_distance {
+                if distance > current_distance {
+                    info!("new max distance: [{}]{:?}", key, state.coords);
+                    self.most_distance = Some((SystemTime::now(), *key, state.coords));
+                }
+            }
+        }
+
+        // Update most airplanes
+        let current_len = airplanes.len();
+        let most_airplanes = self
+            .most_airplanes
+            .map_or(0, |most_airplanes| most_airplanes.1);
+
+        if most_airplanes < current_len as u32 {
+            info!("new most airplanes: {}", current_len);
+            self.most_airplanes = Some((SystemTime::now(), current_len as u32));
+        }
+
+        // Update total airplanes
+        if airplane_added == Added::Yes {
+            self.total_airplanes += 1;
+        }
+    }
+}
 
 /// Render Help tab for tui display
 pub fn build_tab_stats<A: tui::backend::Backend>(
@@ -13,6 +61,7 @@ pub fn build_tab_stats<A: tui::backend::Backend>(
 ) {
     let format = time::format_description::parse("[month]/[day] [hour]:[minute]:[second]").unwrap();
     let mut rows: Vec<Row> = vec![];
+    // Most distance
     let (time, value) = if let Some((time, key, value)) = stats.most_distance {
         let position = value.position.unwrap();
         let lat = format!("{:.DEFAULT_PRECISION$}", position.latitude);
@@ -33,6 +82,7 @@ pub fn build_tab_stats<A: tui::backend::Backend>(
     };
     rows.push(Row::new(vec!["Max Distance", &time, &value]));
 
+    // Most airplanes tracked at one time
     let (time, value) = if let Some((time, most_airplanes)) = stats.most_airplanes {
         // display time
         let datetime = time::OffsetDateTime::from(time);
@@ -48,13 +98,21 @@ pub fn build_tab_stats<A: tui::backend::Backend>(
     };
     rows.push(Row::new(vec!["Most Airplanes", &time, &value]));
 
+    // Total Airplanes Tracked
+    let total_airplanes_s = stats.total_airplanes.to_string();
+    rows.push(Row::new(vec![
+        "Total Airplanes",
+        "All Time",
+        &total_airplanes_s,
+    ]));
+
     // draw table
     let table = Table::new(rows)
         .style(Style::default().fg(Color::White))
         .header(Row::new(vec!["Type", "DateTime", "Value"]).bottom_margin(1))
         .block(Block::default().title("Stats").borders(Borders::ALL))
         .widths(&[
-            Constraint::Length(14),
+            Constraint::Length(16),
             Constraint::Length(15),
             Constraint::Length(200),
         ])


### PR DESCRIPTION
* Added total airplanes tracked. This is all airplanes that were added,
  which does include airplanes that were removed and and then added
  later, but it works
* Moved Stats to src/stats.rs
* common::action() now returns if an Airplane was added or not as the
  Added enum
* Added tracing::info: "info!("[{icao}] now tracking");", when airplane
  is first tracked