### PR TITLE
Display Callsign in Map view

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -39,6 +39,7 @@ OPTIONS:
         --disable-icao                               Disable output of icao address of airplane on Map
         --disable-lat-long                           Disable output of latitude and longitude on Map
         --disable-track                              Disable display of previous positions of aircraft on Map
+        --display-callsign                           Display Callsign / Tail Number instead of ICAO number
         --filter-time <FILTER_TIME>                  Seconds since last message from airplane, triggers removal of airplane after time is up [default: 120]
         --gpsd                                       Enable automatic updating of lat/lon from gpsd(https://gpsd.io/) server
         --gpsd-ip <GPSD_IP>                          Ip address of gpsd [default: localhost]
@@ -87,6 +88,7 @@ This enables those features for platforms without keyboard and mouse usage.
 | i        | control --disable-icao     |
 | h        | control --disable-heading  |
 | t        | control --disable-track    |
+| n        | toggle --diplay-callsign   |
 | TAB      | Move to next tab           |
 | q        | Quit the app               |
 | ctrl + C | Quit the app               |

--- a/apps/src/radar/cli.rs
+++ b/apps/src/radar/cli.rs
@@ -73,6 +73,10 @@ pub struct Opts {
     #[clap(long)]
     pub disable_lat_long: bool,
 
+    /// Display Callsign / Tail Number instead of ICAO number
+    #[clap(long)]
+    pub display_callsign: bool,
+
     /// Disable output of icao address of airplane on Map
     #[clap(long)]
     pub disable_icao: bool,
@@ -144,6 +148,7 @@ mod tests {
             long: -80.0,
             locations: vec![],
             disable_lat_long: false,
+            display_callsign: false,
             scale: 0.12,
             gpsd: false,
             gpsd_ip: "localhost".to_string(),
@@ -187,6 +192,7 @@ mod tests {
                 },
             ],
             disable_lat_long: false,
+            display_callsign: false,
             scale: 0.12,
             gpsd: false,
             gpsd_ip: "localhost".to_string(),

--- a/apps/src/radar/help.rs
+++ b/apps/src/radar/help.rs
@@ -35,6 +35,7 @@ pub fn build_tab_help<A: tui::backend::Backend>(f: &mut tui::Frame<A>, chunks: &
         Row::new(vec!["i", "control --disable-icao"]),
         Row::new(vec!["h", "control --disable-heading"]),
         Row::new(vec!["t", "control --disable-track"]),
+        Row::new(vec!["n", "toggle --display-callsign"]),
         Row::new(vec!["TAB", "Move to Next screen"]),
         Row::new(vec!["q", "Quit this app"]),
         Row::new(vec!["ctrl+c", "Quit this app"]),

--- a/apps/src/radar/map.rs
+++ b/apps/src/radar/map.rs
@@ -25,7 +25,7 @@ pub fn build_tab_map<A: tui::backend::Backend>(
             draw_locations(ctx, settings);
 
             // draw ADSB tab airplanes
-            for key in adsb_airplanes.keys() {
+            for (key, value) in adsb_airplanes.iter() {
                 let aircraft_details = adsb_airplanes.aircraft_details(*key);
                 if let Some(AirplaneDetails {
                     position,
@@ -107,11 +107,21 @@ pub fn build_tab_map<A: tui::backend::Backend>(
                         }
                     }
 
-                    let name = if settings.opts.disable_lat_long {
+                    let call_sign = if settings.opts.display_callsign {
+                        if let Some(callsign) = &value.callsign {
+                            callsign.to_string().into_boxed_str()
+                        } else {
+                            format!("{key}").into_boxed_str()
+                        }
+                    } else {
                         format!("{key}").into_boxed_str()
+                    };
+
+                    let name = if settings.opts.disable_lat_long {
+                        format!("{call_sign}").into_boxed_str()
                     } else {
                         format!(
-                            "{key} ({:.DEFAULT_PRECISION$}, {:.DEFAULT_PRECISION$})",
+                            "{call_sign} ({:.DEFAULT_PRECISION$}, {:.DEFAULT_PRECISION$})",
                             position.latitude, position.longitude
                         )
                         .into_boxed_str()

--- a/apps/src/radar/radar.rs
+++ b/apps/src/radar/radar.rs
@@ -563,6 +563,7 @@ fn handle_keyevent(
         (KeyCode::Char('i'), _) => settings.opts.disable_icao ^= true,
         (KeyCode::Char('h'), _) => settings.opts.disable_heading ^= true,
         (KeyCode::Char('t'), _) => settings.opts.disable_track ^= true,
+        (KeyCode::Char('n'), _) => settings.opts.display_callsign ^= true,
         // Map and Coverage
         (KeyCode::Char('-'), Tab::Map | Tab::Coverage) => settings.scale_increase(),
         (KeyCode::Char('+'), Tab::Map | Tab::Coverage) => settings.scale_decrease(),

--- a/libadsb_deku/src/adsb.rs
+++ b/libadsb_deku/src/adsb.rs
@@ -816,8 +816,11 @@ pub struct OperationCodeSurface {
 #[derive(Debug, PartialEq, Eq, DekuRead, Clone)]
 pub struct Identification {
     pub tc: TypeCoding,
+
     #[deku(bits = "3")]
     pub ca: u8,
+
+    /// N-Number / Tail Number
     #[deku(reader = "aircraft_identification_read(deku::rest)")]
     pub cn: String,
 }


### PR DESCRIPTION
Add display of callsign instead of only showing ICAO hex values. This
can also be controlled from the command line using --display-callsign