### PR TITLE
Max range issue 147

### DIFF
--- a/apps/src/radar/cli.rs
+++ b/apps/src/radar/cli.rs
@@ -166,6 +166,7 @@ mod tests {
             disable_heading: false,
             disable_track: false,
             retry_tcp: false,
+            max_range: 500.0
         };
         assert_eq!(exp_opt, opt);
 
@@ -210,6 +211,7 @@ mod tests {
             disable_heading: false,
             disable_track: false,
             retry_tcp: false,
+            max_range: 500.0,
         };
         assert_eq!(exp_opt, opt);
     }

--- a/apps/src/radar/cli.rs
+++ b/apps/src/radar/cli.rs
@@ -166,7 +166,7 @@ mod tests {
             disable_heading: false,
             disable_track: false,
             retry_tcp: false,
-            max_range: 500.0
+            max_range: 500.0,
         };
         assert_eq!(exp_opt, opt);
 

--- a/apps/src/radar/cli.rs
+++ b/apps/src/radar/cli.rs
@@ -131,6 +131,10 @@ pub struct Opts {
     /// retry TCP connection to dump1090 instance if connecton is lost/disconnected
     #[clap(long)]
     pub retry_tcp: bool,
+
+    /// Control the max range of the receiver in km
+    #[clap(long, default_value = "500")]
+    pub max_range: f64,
 }
 
 #[cfg(test)]

--- a/apps/src/radar/radar.rs
+++ b/apps/src/radar/radar.rs
@@ -394,7 +394,7 @@ fn main() -> Result<()> {
                     Ok((left_over, frame)) => {
                         debug!("ADS-B Frame: {frame}");
                         let airplane_added =
-                            adsb_airplanes.action(frame, (settings.lat, settings.long));
+                            adsb_airplanes.action(frame, (settings.lat, settings.long), settings.opts.max_range);
                         if left_over.1 != 0 {
                             error!("{left_over:x?}");
                         }

--- a/apps/src/radar/radar.rs
+++ b/apps/src/radar/radar.rs
@@ -393,8 +393,11 @@ fn main() -> Result<()> {
                 match frame {
                     Ok((left_over, frame)) => {
                         debug!("ADS-B Frame: {frame}");
-                        let airplane_added =
-                            adsb_airplanes.action(frame, (settings.lat, settings.long), settings.opts.max_range);
+                        let airplane_added = adsb_airplanes.action(
+                            frame,
+                            (settings.lat, settings.long),
+                            settings.opts.max_range,
+                        );
                         if left_over.1 != 0 {
                             error!("{left_over:x?}");
                         }

--- a/rsadsb_common/README.md
+++ b/rsadsb_common/README.md
@@ -10,7 +10,7 @@ Run `cargo doc` in this directory to generate documentation.
 ```rust, ignore
 let mut adsb_airplanes = Airplanes::new();
 if let Ok((bytes_left, frame)) = Frame::from_bytes((&bytes, 0)) {
-    adsb_airplanes.action(frame, (lat, long));
+    adsb_airplanes.action(frame, (lat, long), max_range);
 }
 ```
 

--- a/rsadsb_common/src/lib.rs
+++ b/rsadsb_common/src/lib.rs
@@ -111,9 +111,11 @@ impl Airplanes {
     /// airplanes (`ICAO` and `AirplaneState`) when a new aircraft is detected.
     ///
     /// `lat_long`: (latitude, longitude) of current receiver location
+    /// 
+    /// `max_range`: max range of the receiver
     ///
     /// Return true if entry was added into `Airplanes`
-    pub fn action(&mut self, frame: Frame, lat_long: (f64, f64)) -> Added {
+    pub fn action(&mut self, frame: Frame, lat_long: (f64, f64), max_rang: f64) -> Added {
         let mut airplane_added = Added::No;
         if let DF::ADSB(ref adsb) = frame.df {
             airplane_added = match &adsb.me {

--- a/rsadsb_common/src/lib.rs
+++ b/rsadsb_common/src/lib.rs
@@ -107,7 +107,7 @@ impl Airplanes {
     /// airplanes (`ICAO` and `AirplaneState`) when a new aircraft is detected.
     ///
     /// `lat_long`: (latitude, longitude) of current receiver location
-    /// 
+    ///
     /// `max_range`: max range of the receiver
     ///
     /// Return true if entry was added into `Airplanes`
@@ -256,7 +256,13 @@ impl Airplanes {
     /// update from `ME::AirbornePosition{GNSSAltitude, BaroAltitude}`
     ///
     /// Return true if entry was added into `Airplanes`
-    fn add_altitude(&mut self, icao: ICAO, altitude: &Altitude, lat_long: (f64, f64), max_range: f64) -> Added {
+    fn add_altitude(
+        &mut self,
+        icao: ICAO,
+        altitude: &Altitude,
+        lat_long: (f64, f64),
+        max_range: f64,
+    ) -> Added {
         let (state, airplane_added) = self.entry_or_insert(icao);
         info!(
             "[{icao}] with altitude: {:?}, cpr lat: {}, cpr long: {}",


### PR DESCRIPTION
resolves #147 
Updated clap opts to have a flag with a default of `500`. Pass the `max_range` to where it is needed.