### PR TITLE
Refactor display to disable callsign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.6.1] 2022-09-10
+
+### radar
+- Remove `--display-callsign`, Add `--disable-callsign. Display only ICAO number instead of Callsign / Tail Number
+- Help tab will now show more help
+
 ## [v0.6.0] 2022-08-19
 
 ### rsadsb_common

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.62"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1485d4d2cc45e7b201ee3767015c96faa5904387c9d87c6efdd0fb511f12d305"
+checksum = "b9a8f622bcf6ff3df478e9deba3e03e4e04b300f8e6a139e192c05fa3490afc7"
 dependencies = [
  "backtrace",
 ]
@@ -158,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.17"
+version = "3.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
+checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
 dependencies = [
  "atty",
  "bitflags",
@@ -176,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.17"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13547f7012c01ab4a0e8f8967730ada8f9fdf419e8b6c792788f39cf4e46eefa"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -566,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
 dependencies = [
  "adler",
 ]
@@ -624,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
+checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 
 [[package]]
 name = "oorandom"
@@ -671,9 +671,9 @@ checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "plotters"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "716b4eeb6c4a1d3ecc956f75b43ec2e8e8ba80026413e70a3f41fd3313d3492b"
+checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -819,7 +819,7 @@ version = "0.6.1"
 dependencies = [
  "adsb_deku",
  "anyhow",
- "clap 3.2.17",
+ "clap 3.2.20",
  "crossterm",
  "csv",
  "gpsd_proto",
@@ -1017,18 +1017,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.32"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
+checksum = "8c1b05ca9d106ba7d2e31a9dab4a64e7be2cce415321966ea3132c49a656e252"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.32"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
+checksum = "e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "adsb_deku"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "assert_hex",
  "criterion",
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "508b352bb5c066aac251f6daf6b36eccd03e8a88e8081cd44959ea277a3af9a8"
+checksum = "1485d4d2cc45e7b201ee3767015c96faa5904387c9d87c6efdd0fb511f12d305"
 dependencies = [
  "backtrace",
 ]
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
 name = "cassowary"
@@ -384,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "fnv"
@@ -511,9 +511,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.131"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c3b4822ccebfa39c02fc03d1534441b22ead323fa0f48bb7ddd8e6ba076a40"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "libm"
@@ -523,9 +523,9 @@ checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
 
 [[package]]
 name = "lock_api"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+checksum = "9f80bf5aacaf25cbfc8210d1cfb718f2bf3b11c4c54e5afe36c236853a8ec390"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -624,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "oorandom"
@@ -671,9 +671,9 @@ checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "plotters"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9428003b84df1496fb9d6eeee9c5f8145cb41ca375eb0dad204328888832811f"
+checksum = "716b4eeb6c4a1d3ecc956f75b43ec2e8e8ba80026413e70a3f41fd3313d3492b"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -690,9 +690,9 @@ checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0918736323d1baff32ee0eade54984f6f201ad7e97d5cfb5d6ab4a358529615"
+checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
 dependencies = [
  "plotters-backend",
 ]
@@ -815,7 +815,7 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "rsadsb_apps"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "adsb_deku",
  "anyhow",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "rsadsb_common"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "adsb_deku",
  "libm",
@@ -871,9 +871,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.143"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
+checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 dependencies = [
  "serde_derive",
 ]
@@ -890,9 +890,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.143"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
+checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -901,9 +901,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
  "itoa 1.0.3",
  "ryu",
@@ -1046,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db76ff9fa4b1458b3c7f077f3ff9887394058460d21e634355b273aaf11eea45"
+checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
 dependencies = [
  "itoa 1.0.3",
  "libc",

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Decoder for [ADS-B(Automatic Dependent Surveillance-Broadcast)](https://en.wikip
 
 See [quickstart-guide](https://rsadsb.github.io/quickstart.html) for a quick installation guide.
 
-See [rsadsb-v0.5.0](https://rsadsb.github.io/v0.5.0.html) for latest major release details.
+See [rsadsb-v0.6.0](https://rsadsb.github.io/v0.6.0.html) for latest major release details.
 
 This library uses [deku](https://github.com/sharksforarms/deku) for deserialization of protocol.
 

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsadsb_apps"
-version = "0.6.0"
+version = "0.6.1"
 license = "MIT"
 edition = "2021"
 rust-version = "1.59.0"

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -14,8 +14,8 @@ name = "1090"
 path = "src/1090/1090.rs"
 
 [dependencies]
-adsb_deku = { path = "../libadsb_deku", version = "0.6.0" }
-rsadsb_common = { path = "../rsadsb_common", version = "0.6.0" }
+adsb_deku = { path = "../libadsb_deku", version = "0.6.1" }
+rsadsb_common = { path = "../rsadsb_common", version = "0.6.1" }
 hex = "0.4.0"
 crossterm = "0.25.0"
 clap = {version = "3.1.0", features = ["color", "derive", "wrap_help"]}

--- a/apps/README.md
+++ b/apps/README.md
@@ -2,30 +2,10 @@
 
 See main README.md for app sample images.
 
-## 1090
-See `--help` for more information.
-```
-1090 0.5.1
-wcampbell0x2a
-Dump ADS-B protocol info from demodulator
-
-USAGE:
-    1090 [OPTIONS]
-
-OPTIONS:
-        --debug            Display debug of adsb::Frame
-    -h, --help             Print help information
-        --host <HOST>      ip address of ADS-B demodulated bytes server [default: localhost]
-        --panic-decode     Panic on adsb_deku::Frame::from_bytes() error
-        --panic-display    Panic on adsb_deku::Frame::fmt::Display not implemented
-        --port <PORT>      port of ADS-B demodulated bytes server [default: 30002]
-    -V, --version          Print version information
-```
-
 ## radar
 See `--help` for more information.
 ```
-radar 0.5.1
+adar 0.6.1
 wcampbell0x2a
 TUI Display of ADS-B protocol info from demodulator
 
@@ -33,31 +13,32 @@ USAGE:
     radar [OPTIONS] --lat <LAT> --long <LONG>
 
 OPTIONS:
-        --airports <AIRPORTS>                        Import downloaded csv file for FAA Airport from https://github.com/mborsetti/airportsdata
-        --airports-tz-filter <AIRPORTS_TZ_FILTER>    comma seperated filter for --airports timezone data, such as: "America/Chicago,America/New_York"
-        --disable-heading                            Disable display of angles on aircraft within Map display showing the direction of the aircraft
-        --disable-icao                               Disable output of icao address of airplane on Map
-        --disable-lat-long                           Disable output of latitude and longitude on Map
-        --disable-track                              Disable display of previous positions of aircraft on Map
-        --display-callsign                           Display Callsign / Tail Number instead of ICAO number
-        --filter-time <FILTER_TIME>                  Seconds since last message from airplane, triggers removal of airplane after time is up [default: 120]
-        --gpsd                                       Enable automatic updating of lat/lon from gpsd(https://gpsd.io/) server
-        --gpsd-ip <GPSD_IP>                          Ip address of gpsd [default: localhost]
-    -h, --help                                       Print help information
         --host <HOST>                                ip address / hostname of ADS-B server / demodulator [default: 127.0.0.1]
-        --lat <LAT>                                  Antenna location latitude, this use for aircraft position algorithms
-        --limit-parsing                              Limit parsing of ADS-B messages to `DF::ADSB(17)` num_messages
-        --locations <LOCATIONS>...                   Vector of location [(name, lat, long),..] to display on Map
-        --log-folder <LOG_FOLDER>                    [default: logs]
-        --long <LONG>                                Antenna location longitude
         --port <PORT>                                port of ADS-B server / demodulator [default: 30002]
+        --lat <LAT>                                  Antenna location latitude, this use for aircraft position algorithms
+        --long <LONG>                                Antenna location longitude
+        --locations <LOCATIONS>...                   Vector of location [(name, lat, long),..] to display on Map
+        --disable-lat-long                           Disable output of latitude and longitude on Map
+        --display-callsign                           Display Callsign / Tail Number instead of ICAO number
+        --disable-icao                               Disable output of icao address of airplane on Map
+        --disable-heading                            Disable display of angles on aircraft within Map display showing the direction of the aircraft
+        --disable-track                              Disable display of previous positions of aircraft on Map
         --scale <SCALE>                              Zoom level of Map and Coverage (-=zoom out/+=zoom in) [default: .12]
+        --gpsd                                       Enable automatic updating of lat/lon from gpsd(<https://gpsd.io/>) server
+        --gpsd-ip <GPSD_IP>                          Ip address of gpsd [default: localhost]
+        --filter-time <FILTER_TIME>                  Seconds since last message from airplane, triggers removal of airplane after time is up [default: 120]
+        --log-folder <LOG_FOLDER>                    [default: logs]
         --touchscreen                                Enable three tabs on left side of screen for zoom out/zoom in/and reset
+        --limit-parsing                              Limit parsing of ADS-B messages to `DF::ADSB(17)` num_messages
+        --airports <AIRPORTS>                        Import downloaded csv file for FAA Airport from <https://github.com/mborsetti/airportsdata>
+        --airports-tz-filter <AIRPORTS_TZ_FILTER>    comma seperated filter for --airports timezone data, such as: "America/Chicago,America/New_York"
+        --retry-tcp                                  retry TCP connection to dump1090 instance if connecton is lost/disconnected
+        --max-range <MAX_RANGE>                      Control the max range of the receiver in km [default: 500]
+    -h, --help                                       Print help information
     -V, --version                                    Print version information
 
 Environment Variables:
-    RUST_LOG: See "https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/index.html#filtering-events-with-environment-
-variables"
+    RUST_LOG: See "https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/index.html#filtering-events-with-environment-variables"
 ```
 
 ### Logging
@@ -111,6 +92,27 @@ This enables those features for platforms without keyboard and mouse usage.
 | Up    | Move selection upward      |
 | Down  | Move selection downward    |
 | Enter | Center Map tab on aircraft |
+
+## 1090
+See `--help` for more information.
+```
+1090 0.6.1
+wcampbell0x2a
+Dump ADS-B protocol info from demodulator
+
+USAGE:
+    1090 [OPTIONS]
+
+OPTIONS:
+        --debug            Display debug of adsb::Frame
+    -h, --help             Print help information
+        --host <HOST>      ip address of ADS-B demodulated bytes server [default: localhost]
+        --panic-decode     Panic on adsb_deku::Frame::from_bytes() error
+        --panic-display    Panic on adsb_deku::Frame::fmt::Display not implemented
+        --port <PORT>      port of ADS-B demodulated bytes server [default: 30002]
+    -V, --version          Print version information
+```
+
 
 ## Contributing
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -5,7 +5,7 @@ See main README.md for app sample images.
 ## radar
 See `--help` for more information.
 ```
-adar 0.6.1
+radar 0.6.1
 wcampbell0x2a
 TUI Display of ADS-B protocol info from demodulator
 
@@ -19,7 +19,7 @@ OPTIONS:
         --long <LONG>                                Antenna location longitude
         --locations <LOCATIONS>...                   Vector of location [(name, lat, long),..] to display on Map
         --disable-lat-long                           Disable output of latitude and longitude on Map
-        --display-callsign                           Display Callsign / Tail Number instead of ICAO number
+        --disable-callsign                           Display only ICAO number instead of Callsign / Tail Number
         --disable-icao                               Disable output of icao address of airplane on Map
         --disable-heading                            Disable display of angles on aircraft within Map display showing the direction of the aircraft
         --disable-track                              Disable display of previous positions of aircraft on Map

--- a/apps/src/radar/cli.rs
+++ b/apps/src/radar/cli.rs
@@ -43,6 +43,7 @@ const AFTER_TEST: &str = r#"Environment Variables:
     author = "wcampbell0x2a",
     about = "TUI Display of ADS-B protocol info from demodulator",
     after_help = AFTER_TEST,
+    settings = &[clap::AppSettings::DeriveDisplayOrder],
 )]
 pub struct Opts {
     /// ip address / hostname of ADS-B server / demodulator
@@ -75,7 +76,7 @@ pub struct Opts {
 
     /// Display Callsign / Tail Number instead of ICAO number
     #[clap(long)]
-    pub display_callsign: bool,
+    pub disable_callsign: bool,
 
     /// Disable output of icao address of airplane on Map
     #[clap(long)]
@@ -152,7 +153,7 @@ mod tests {
             long: -80.0,
             locations: vec![],
             disable_lat_long: false,
-            display_callsign: false,
+            disable_callsign: false,
             scale: 0.12,
             gpsd: false,
             gpsd_ip: "localhost".to_string(),
@@ -197,7 +198,7 @@ mod tests {
                 },
             ],
             disable_lat_long: false,
-            display_callsign: false,
+            disable_callsign: false,
             scale: 0.12,
             gpsd: false,
             gpsd_ip: "localhost".to_string(),

--- a/apps/src/radar/cli.rs
+++ b/apps/src/radar/cli.rs
@@ -74,7 +74,7 @@ pub struct Opts {
     #[clap(long)]
     pub disable_lat_long: bool,
 
-    /// Display Callsign / Tail Number instead of ICAO number
+    /// Display only ICAO number instead of Callsign / Tail Number
     #[clap(long)]
     pub disable_callsign: bool,
 

--- a/apps/src/radar/help.rs
+++ b/apps/src/radar/help.rs
@@ -17,9 +17,9 @@ pub fn build_tab_help<A: tui::backend::Backend>(f: &mut tui::Frame<A>, chunks: &
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Percentage(2),
-            Constraint::Percentage(30),
-            Constraint::Percentage(30),
-            Constraint::Percentage(30),
+            Constraint::Percentage(40),
+            Constraint::Percentage(40),
+            Constraint::Percentage(10),
             Constraint::Percentage(2),
         ])
         .split(horizontal_chunks[1]);
@@ -35,7 +35,7 @@ pub fn build_tab_help<A: tui::backend::Backend>(f: &mut tui::Frame<A>, chunks: &
         Row::new(vec!["i", "control --disable-icao"]),
         Row::new(vec!["h", "control --disable-heading"]),
         Row::new(vec!["t", "control --disable-track"]),
-        Row::new(vec!["n", "toggle --display-callsign"]),
+        Row::new(vec!["n", "toggle --disable-callsign"]),
         Row::new(vec!["TAB", "Move to Next screen"]),
         Row::new(vec!["q", "Quit this app"]),
         Row::new(vec!["ctrl+c", "Quit this app"]),

--- a/apps/src/radar/map.rs
+++ b/apps/src/radar/map.rs
@@ -107,14 +107,14 @@ pub fn build_tab_map<A: tui::backend::Backend>(
                         }
                     }
 
-                    let call_sign = if settings.opts.display_callsign {
+                    let call_sign = if settings.opts.disable_callsign {
+                        format!("{key}").into_boxed_str()
+                    } else {
                         if let Some(callsign) = &value.callsign {
                             callsign.to_string().into_boxed_str()
                         } else {
                             format!("{key}").into_boxed_str()
                         }
-                    } else {
-                        format!("{key}").into_boxed_str()
                     };
 
                     let name = if settings.opts.disable_lat_long {

--- a/apps/src/radar/map.rs
+++ b/apps/src/radar/map.rs
@@ -109,12 +109,10 @@ pub fn build_tab_map<A: tui::backend::Backend>(
 
                     let call_sign = if settings.opts.disable_callsign {
                         format!("{key}").into_boxed_str()
+                    } else if let Some(callsign) = &value.callsign {
+                        callsign.to_string().into_boxed_str()
                     } else {
-                        if let Some(callsign) = &value.callsign {
-                            callsign.to_string().into_boxed_str()
-                        } else {
-                            format!("{key}").into_boxed_str()
-                        }
+                        format!("{key}").into_boxed_str()
                     };
 
                     let name = if settings.opts.disable_lat_long {

--- a/apps/src/radar/radar.rs
+++ b/apps/src/radar/radar.rs
@@ -566,7 +566,7 @@ fn handle_keyevent(
         (KeyCode::Char('i'), _) => settings.opts.disable_icao ^= true,
         (KeyCode::Char('h'), _) => settings.opts.disable_heading ^= true,
         (KeyCode::Char('t'), _) => settings.opts.disable_track ^= true,
-        (KeyCode::Char('n'), _) => settings.opts.display_callsign ^= true,
+        (KeyCode::Char('n'), _) => settings.opts.disable_callsign ^= true,
         // Map and Coverage
         (KeyCode::Char('-'), Tab::Map | Tab::Coverage) => settings.scale_increase(),
         (KeyCode::Char('+'), Tab::Map | Tab::Coverage) => settings.scale_decrease(),

--- a/libadsb_deku/Cargo.toml
+++ b/libadsb_deku/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adsb_deku"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "MIT"
 description = "Decoder for ADS-B(Automatic Depedent Surveillance-Broadcast) - written with deku"

--- a/rsadsb_common/Cargo.toml
+++ b/rsadsb_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsadsb_common"
-version = "0.6.0"
+version = "0.6.1"
 license = "MIT"
 edition = "2021"
 rust-version = "1.59.0"

--- a/rsadsb_common/Cargo.toml
+++ b/rsadsb_common/Cargo.toml
@@ -11,6 +11,6 @@ std = ["adsb_deku/std", "tracing/std", "alloc"]
 alloc = ["adsb_deku/alloc", "tracing"]
 
 [dependencies]
-adsb_deku = { path = "../libadsb_deku", version = "0.6.0", default-features = false }
+adsb_deku = { path = "../libadsb_deku", version = "0.6.1", default-features = false }
 tracing = { version = "0.1.0", default-features = false, optional = true}
 libm = "0.2.2"


### PR DESCRIPTION
* --display-callsign not does the exact inverse of what it used to, and
  now only displays the display of the callsign instead of the ICAO.
* use clap::AppSettings::DeriveDisplayOrder to show --help and -h in the
  same order of the arguments in my definition
* update versions in readme to v0.6.1
