### PR TITLE
Add circular range indication graphics to coverage screen #148

### DIFF
--- a/apps/src/radar/cli.rs
+++ b/apps/src/radar/cli.rs
@@ -25,6 +25,19 @@ impl FromStr for Location {
     }
 }
 
+/// Parsing struct for the --range-circles clap parameter
+#[derive(Debug, Clone, PartialEq)]
+pub struct RangeCircles(pub Vec<f64>);
+
+impl FromStr for RangeCircles {
+    type Err = ParseFloatError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let ranges: Result<Vec<f64>, ParseFloatError> = s.split(',').map(|r| r.parse::<f64>()).collect();
+        Ok(Self(ranges?))
+    }
+}
+
 const AFTER_TEST: &str = r#"Environment Variables:
     RUST_LOG: See "https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/index.html#filtering-events-with-environment-variables"
 "#;
@@ -128,6 +141,15 @@ pub struct Opts {
     /// Control the max range of the receiver in km
     #[arg(long, default_value = "500")]
     pub max_range: f64,
+    
+    /// Comma-separated list of range circles to display (in km)
+    /// Example: --range-circles=100,200,300,400
+    #[arg(long, default_value = "100,200,300,400")]
+    pub range_circles: RangeCircles,
+    
+    /// Disable display of range circles on Map and Coverage
+    #[arg(long)]
+    pub disable_range_circles: bool,
 }
 
 #[cfg(test)]
@@ -160,6 +182,8 @@ mod tests {
             disable_track: false,
             retry_tcp: false,
             max_range: 500.0,
+            range_circles: RangeCircles(vec![100.0, 200.0, 300.0, 400.0]),
+            disable_range_circles: false,
         };
         assert_eq!(exp_opt, opt);
 
@@ -197,6 +221,8 @@ mod tests {
             disable_track: false,
             retry_tcp: false,
             max_range: 500.0,
+            range_circles: RangeCircles(vec![100.0, 200.0, 300.0, 400.0]),
+            disable_range_circles: false,
         };
         assert_eq!(exp_opt, opt);
     }

--- a/apps/src/radar/cli.rs
+++ b/apps/src/radar/cli.rs
@@ -1,7 +1,6 @@
 use std::net::Ipv4Addr;
 use std::num::ParseFloatError;
 use std::str::FromStr;
-
 use clap::Parser;
 
 /// Parsing struct for the --locations clap parameter

--- a/apps/src/radar/coverage.rs
+++ b/apps/src/radar/coverage.rs
@@ -2,7 +2,7 @@ use adsb_deku::cpr::Position;
 use adsb_deku::ICAO;
 use ratatui::layout::Rect;
 use ratatui::style::Color;
-use ratatui::widgets::canvas::{Canvas, Points};
+use ratatui::widgets::canvas::{Canvas, Points, Line, Circle};
 use ratatui::widgets::Block;
 use rsadsb_common::Airplanes;
 
@@ -61,6 +61,52 @@ pub fn populate_coverage(
     }
 }
 
+/// Draw range circles around the receiver location
+fn draw_range_circles(
+    ctx: &mut ratatui::widgets::canvas::Context<'_>,
+    settings: &Settings,
+) {
+    // Skip drawing if disabled
+    if settings.opts.disable_range_circles {
+        return;
+    }
+    
+    // Get the range circles from the command line options
+    let ranges = &settings.opts.range_circles.0;
+    
+    // Get the receiver location (0,0) in the canvas coordinates
+    let (x, y) = settings.to_xy(settings.lat, settings.long);
+    
+    // Draw each range circle
+    for &range in ranges {
+
+        let lat_offset = range / 111.0;
+        let point_at_range = settings.to_xy(settings.lat + lat_offset, settings.long);
+        
+        // Calculate the radius in canvas units
+        let radius = ((point_at_range.1 - y).powi(2) + (point_at_range.0 - x).powi(2)).sqrt();
+        
+        // Draw the circle
+        ctx.draw(&Circle {
+            x,
+            y,
+            radius,
+            color: Color::DarkGray,
+        });
+        
+        let label_x = x;
+        let label_y = y - radius;
+        ctx.print(
+            label_x,
+            label_y,
+            ratatui::text::Span::styled(
+                format!("{}km", range),
+                ratatui::style::Style::default().fg(Color::DarkGray),
+            ),
+        );
+    }
+}
+
 /// Render Coverage tab for tui display
 pub fn build_tab_coverage(
     f: &mut ratatui::Frame,
@@ -75,6 +121,9 @@ pub fn build_tab_coverage(
         .paint(|ctx| {
             // draw locations
             draw_locations(ctx, settings);
+            
+            // draw range circles
+            draw_range_circles(ctx, settings);
 
             // draw ADSB tab airplanes
             for (lat, long, seen_number, _) in coverage_airplanes.iter() {

--- a/apps/src/radar/coverage.rs
+++ b/apps/src/radar/coverage.rs
@@ -2,7 +2,7 @@ use adsb_deku::cpr::Position;
 use adsb_deku::ICAO;
 use ratatui::layout::Rect;
 use ratatui::style::Color;
-use ratatui::widgets::canvas::{Canvas, Points, Line, Circle};
+use ratatui::widgets::canvas::{Canvas, Points, Circle};
 use ratatui::widgets::Block;
 use rsadsb_common::Airplanes;
 

--- a/apps/src/radar/help.rs
+++ b/apps/src/radar/help.rs
@@ -17,8 +17,9 @@ pub fn build_tab_help(f: &mut ratatui::Frame, chunks: &[Rect]) {
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Percentage(2),
-            Constraint::Percentage(40),
-            Constraint::Percentage(40),
+            Constraint::Percentage(35),
+            Constraint::Percentage(35),
+            Constraint::Percentage(10),
             Constraint::Percentage(10),
             Constraint::Percentage(2),
         ])
@@ -36,6 +37,7 @@ pub fn build_tab_help(f: &mut ratatui::Frame, chunks: &[Rect]) {
         Row::new(vec!["h", "control --disable-heading"]),
         Row::new(vec!["t", "control --disable-track"]),
         Row::new(vec!["n", "toggle --disable-callsign"]),
+        Row::new(vec!["r", "toggle --disable-range-circles"]),
         Row::new(vec!["TAB", "Move to Next screen"]),
         Row::new(vec!["q", "Quit this app"]),
         Row::new(vec!["ctrl+c", "Quit this app"]),
@@ -77,4 +79,17 @@ pub fn build_tab_help(f: &mut ratatui::Frame, chunks: &[Rect]) {
         .column_spacing(1)
         .block(Block::bordered().title("Key Bindings - Airplanes"));
     f.render_widget(table, vertical_chunks[3]);
+    
+    // Range circles help section
+    let rows = [
+        Row::new(vec!["--range-circles", "Set range circles (km) as comma-separated values"]),
+        Row::new(vec!["--disable-range-circles", "Hide range circles"]),
+        Row::new(vec!["r", "Toggle range circles visibility"]),
+    ];
+    let table = Table::new(rows, widths)
+        .style(Style::default().fg(Color::White))
+        .header(Row::new(vec!["Option", "Description"]).bottom_margin(1))
+        .column_spacing(1)
+        .block(Block::bordered().title("Range Circles"));
+    f.render_widget(table, vertical_chunks[4]);
 }

--- a/apps/src/radar/radar.rs
+++ b/apps/src/radar/radar.rs
@@ -556,6 +556,7 @@ fn handle_keyevent(
         (KeyCode::Char('h'), _) => settings.opts.disable_heading ^= true,
         (KeyCode::Char('t'), _) => settings.opts.disable_track ^= true,
         (KeyCode::Char('n'), _) => settings.opts.disable_callsign ^= true,
+        (KeyCode::Char('r'), _) => settings.opts.disable_range_circles ^= true,
         // Map and Coverage
         (KeyCode::Char('-'), Tab::Map | Tab::Coverage) => settings.scale_increase(),
         (KeyCode::Char('+'), Tab::Map | Tab::Coverage) => settings.scale_decrease(),


### PR DESCRIPTION
Added RangeCircles

100km, 200kn, 300km, 400km 

each circle is labeled with its distance

CLI:

--range-circles to specify custom distance

--disable-range-circles to hide them