### PR TITLE
Fix off-by-one in aircraft_identification_read

### DIFF
--- a/apps/src/radar/radar.rs
+++ b/apps/src/radar/radar.rs
@@ -509,11 +509,11 @@ fn init_tcp_reader(
                         settings.quit = Some(QuitReason::UserRequested);
                         return Ok(None);
                     }
-                    KeyCode::Char('c') => {
-                        if modifiers == crossterm::event::KeyModifiers::CONTROL {
-                            settings.quit = Some(QuitReason::UserRequested);
-                            return Ok(None);
-                        }
+                    KeyCode::Char('c')
+                        if modifiers == crossterm::event::KeyModifiers::CONTROL =>
+                    {
+                        settings.quit = Some(QuitReason::UserRequested);
+                        return Ok(None);
                     }
                     // unknown key
                     _ => (),
@@ -548,10 +548,8 @@ fn handle_keyevent(
         (KeyCode::F(5), _) => settings.tab_selection = Tab::Help,
         (KeyCode::Tab, _) => settings.tab_selection = settings.tab_selection.next_tab(),
         (KeyCode::Char('q'), _) => settings.quit = Some(QuitReason::UserRequested),
-        (KeyCode::Char('c'), _) => {
-            if modifiers == crossterm::event::KeyModifiers::CONTROL {
-                settings.quit = Some(QuitReason::UserRequested);
-            }
+        (KeyCode::Char('c'), _) if modifiers == crossterm::event::KeyModifiers::CONTROL => {
+            settings.quit = Some(QuitReason::UserRequested);
         }
         (KeyCode::Char('l'), _) => settings.opts.disable_lat_long ^= true,
         (KeyCode::Char('i'), _) => settings.opts.disable_icao ^= true,

--- a/libadsb_deku/src/lib.rs
+++ b/libadsb_deku/src/lib.rs
@@ -895,7 +895,7 @@ pub(crate) fn aircraft_identification_read<R: Read + Seek>(
     reader: &mut Reader<R>,
 ) -> Result<String, DekuError> {
     let mut chars = vec![];
-    for _ in 0..=6 {
+    for _ in 0..=7 {
         let c = <u8>::from_reader_with_ctx(reader, BitSize(6))?;
         if c != 32 {
             chars.push(c);

--- a/libadsb_deku/tests/test.rs
+++ b/libadsb_deku/tests/test.rs
@@ -464,6 +464,22 @@ fn testing_aircraftidentificationandcategory() {
 }
 
 #[test]
+fn testing_aircraftidentification_8char_callsign() {
+    let bytes = hex!("8daabbcc20485043230c31bbf834");
+    let frame = Frame::from_bytes(&bytes).unwrap();
+    let resulting_string = format!("{frame}");
+    assert_eq!(
+        r#" Extended Squitter Aircraft identification and category
+  Address:       aabbcc (Mode S / ADS-B)
+  Air/Ground:    airborne
+  Ident:         REACH001
+  Category:      A0
+"#,
+        resulting_string
+    );
+}
+
+#[test]
 fn testing_issue_01() {
     let bytes = hex!("8dad50a9ea466867811c08abbaa2");
     let frame = Frame::from_bytes(&bytes).unwrap();


### PR DESCRIPTION
The callsign field in ADS-B identification messages is 48 bits (8 characters at 6 bits each), but the loop only iterated 7 times (0..=6), silently dropping the 8th character. Most callsigns are 7 characters or fewer so this went unnoticed, but full 8-char callsigns get truncated.

Added a test with an 8-character callsign that would fail without this fix.